### PR TITLE
Upload PDF file artifact on every check

### DIFF
--- a/.github/workflows/build-latex.yaml
+++ b/.github/workflows/build-latex.yaml
@@ -3,8 +3,8 @@ name: Build Document
 on:
   pull_request:
     branches: [main]
-    # paths-ignore:
-    #   - '.github/**'
+    paths-ignore:
+      - '.github/**'
 
 jobs:
   build_latex:

--- a/.github/workflows/build-latex.yaml
+++ b/.github/workflows/build-latex.yaml
@@ -3,6 +3,8 @@ name: Build Document
 on:
   pull_request:
     branches: [main]
+    # paths-ignore:
+    #   - '.github/**'
 
 jobs:
   build_latex:
@@ -15,3 +17,9 @@ jobs:
         uses: xu-cheng/latex-action@v3
         with:
           root_file: main.tex
+
+      - name: Upload pdf as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: RULE_BOOK_PDF
+          path: main.pdf


### PR DESCRIPTION
This change adds an upload step to the workflow, which checks if the document is building correctly. Every workflow call will have an artifact as a zip file with the rule book PDF within available for download. Additionally, if changes are in `.github` directory only, the workflow will be skipped, as running it in this case would be wasteful.

The file will be at the bottom of the workflow summary view:
![image](https://github.com/Heegu-sama/Homm3BG/assets/5611195/14432d17-0627-4c87-b349-184c9fd43cf5)
