### PR TITLE
Clarification to losing neutral combat

### DIFF
--- a/sections/combat.tex
+++ b/sections/combat.tex
@@ -142,7 +142,8 @@ Combat can end in the following ways:
 \end{itemize}
 In combat against \textbf{Neutral Units}, if the player defeats all opposing Units they win the combat.
 If the player \hyperlink{Timelimit}{runs out of time} or all of their Units are defeated, they instead have to \textbf{Retreat}; move any surviving Units back to your Unit Deck and move the Hero that started the Combat back to the Field they last Visited.
-There are no other negative consequences.\par
+There are no other negative consequences.
+\textbf{Important exception}: If \textbf{all} of your Units from your Unit Deck were defeated during that Neutral Combat, your Main Hero must instead be moved to a friendly Town or Settlement. Secondary Heroes are removed from the game until Recruited again.\par
 If you defeat all Units \textbf{during combat against another player's Main Hero}, the defeated player \textbf{loses Morale} and has to \textbf{pay the winner} 5 \includesvg[height=10px]{\svgs/gold.svg}.
 Do not lose Morale or pay \includesvg[height=10px]{\svgs/gold.svg} if a \textbf{Secondary Hero} is defeated.
 \textbf{In both cases}, the defeated player also \textbf{gives the winner} one of their \hyperlink{End}{faction cubes}.


### PR DESCRIPTION
If you lose ALL units against neutrals, your hero model will act as if they were defeated by a player. Just confirmed in the FAQ thread.