### PR TITLE
Make location images evenly distributed on page

### DIFF
--- a/sections/all_map_locations.tex
+++ b/sections/all_map_locations.tex
@@ -84,7 +84,7 @@ Do not place any resource tokens on the settlement if you choose to reinforce.
   \begin{minipage}[t]{0.47\textwidth}
     \vspace{0pt}
     \centering
-    \textbf{Library}\medskip
+    \textbf{Library}\par
     \shadowimage[width=\textwidth]{\images/library.jpg}
     \caption{\small Category: \textbf{Revisitable}\\You may
       \includesvg[height=8px]{\svgs/pay_v2.svg}
@@ -96,7 +96,7 @@ Do not place any resource tokens on the settlement if you choose to reinforce.
     \vspace{0pt}
     \centering
     \captionsetup{singlelinecheck=off}
-    \textbf{Black Market}\medskip
+    \phantom{j}\textbf{Black Market}\par
     \shadowimage[width=\textwidth]{\images/black_market.jpg}
     \caption[black market]{\small Category: \textbf{Revisitable}\\Look at the top 4 cards from the Artifact discard pile.
       You may buy one of them for:
@@ -114,7 +114,7 @@ Do not place any resource tokens on the settlement if you choose to reinforce.
   \begin{minipage}[t]{0.47\textwidth}
     \vspace{0pt}
     \centering
-    \textbf{Sanctuary}\medskip
+    \textbf{Sanctuary}\par
     \shadowimage[width=\textwidth]{\images/sanctuary.jpg}
     \caption{\small Category: \textbf{Revisitable}\\
       Heroes on this field cannot be attacked by other Heroes.
@@ -123,7 +123,7 @@ Do not place any resource tokens on the settlement if you choose to reinforce.
   \begin{minipage}[t]{0.47\textwidth}
     \vspace{0pt}
     \centering
-    \textbf{Tavern}\medskip
+    \phantom{j}\textbf{Tavern}\par
     \shadowimage[width=\textwidth]{\images/tavern.jpg}
     \caption{\small Category: \textbf{Revisitable}\\
       You can \includesvg[height=8px]{\svgs/pay_v2.svg}
@@ -138,7 +138,7 @@ Do not place any resource tokens on the settlement if you choose to reinforce.
   \begin{minipage}[t]{0.47\textwidth}
     \vspace{0pt}
     \centering
-    \hypertarget{Trading Post}{\textbf{Trading Post}}\medskip
+    \hypertarget{Trading Post}{\textbf{Trading Post}}\par
     \shadowimage[width=\textwidth]{\images/trading_post.jpg}
     \caption{\small Category: \textbf{Revisitable}\\
       Exchange resources or Remove a card.
@@ -147,7 +147,7 @@ Do not place any resource tokens on the settlement if you choose to reinforce.
   \begin{minipage}[t]{0.47\textwidth}
     \vspace{0pt}
     \centering
-    \textbf{Stables}\medskip
+    \phantom{j}\textbf{Stables}\par
     \shadowimage[width=\textwidth]{\images/stables.jpg}
     \caption{\small Category: \textbf{Revisitable}\\
       Gain 1 MP \includesvg[height=8px]{\svgs/movement.svg}.
@@ -164,7 +164,7 @@ The effects of these fields are only indicated by a question mark on their tiles
   \begin{minipage}[t]{0.47\textwidth}
     \vspace{0pt}
     \centering
-    \textbf{Tree Of Knowledge}\medskip
+    \textbf{Tree Of Knowledge}\par
     \shadowimage[width=\linewidth]{\images/tree.jpg}
     \caption{\small Category: \textbf{Visitable}\\You may
       \includesvg[height=8px]{\svgs/pay_v2.svg}
@@ -175,7 +175,7 @@ The effects of these fields are only indicated by a question mark on their tiles
   \begin{minipage}[t]{0.47\textwidth}
     \vspace{0pt}
     \centering
-    \textbf{Redwood Observatory}\medskip
+    \textbf{Redwood Observatory}\par
     \shadowimage[width=\linewidth]{\images/observatory.jpg}
     \caption{\small Category: \textbf{Visitable}\\Discover a tile adjacent to this one.}
   \end{minipage}
@@ -185,7 +185,7 @@ The effects of these fields are only indicated by a question mark on their tiles
   \begin{minipage}[t]{0.47\textwidth}
     \vspace{0pt}
     \centering
-    \textbf{Grail}\medskip
+    \phantom{j}\textbf{Grail}\par
     \shadowimage[width=\linewidth]{\images/grail.jpg}
     % \caption{\small Category: \textbf{Visitable}\\Gain a Grail token.}
     \caption{\small Category: \textbf{Visitable}\\Gain a Grail token.\phantom{\ldots\ldots\ldots}}
@@ -193,7 +193,7 @@ The effects of these fields are only indicated by a question mark on their tiles
   \begin{minipage}[t]{0.47\textwidth}
     \vspace{0pt}
     \centering
-    \textbf{Dragon Utopia}\medskip
+    \textbf{Dragon Utopia}\par
     \shadowimage[width=\linewidth]{\images/dragon_utopia.jpg}
     \caption{\small Category: \textbf{Flaggable}\\Effects depend on scenario.}
   \end{minipage}
@@ -203,7 +203,7 @@ The effects of these fields are only indicated by a question mark on their tiles
   \begin{minipage}[t]{0.47\textwidth}
     \vspace{0pt}
     \centering
-    \textbf{Market Of Time}\medskip
+    \phantom{j}\textbf{Market Of Time}\par
     \shadowimage[width=\linewidth]{\images/market_of_time.jpg}
     \caption{\small Category: \textbf{Visitable}\\ Remove one card from your hand.
 Then \textbf{Search (2)} Ability, Spell, or Artifact deck.}
@@ -211,7 +211,7 @@ Then \textbf{Search (2)} Ability, Spell, or Artifact deck.}
   \begin{minipage}[t]{0.47\textwidth}
     \vspace{0pt}
     \centering
-    \textbf{University}\medskip
+    \textbf{University}\par
     \shadowimage[width=\linewidth]{\images/university.jpg}
     \caption{\small Category: \textbf{Visitable}\\
       \includesvg[height=8px]{\svgs/pay_v2.svg} 6 \includesvg[height=8px]{\svgs/gold.svg} to \textbf{Search (4)} the Ability discard pile.}
@@ -222,7 +222,7 @@ Then \textbf{Search (2)} Ability, Spell, or Artifact deck.}
   \begin{minipage}[t]{0.47\textwidth}
     \vspace{0pt}
     \centering
-    \textbf{Magic Spring}\medskip
+    \textbf{Magic Spring}\par
     \shadowimage[width=\linewidth]{\images/magic_spring.jpg}
     \caption{\small Category: \textbf{Visitable}\\
       You may look at the top 3 cards of your discard pile and take 1 of them back to your hand.
@@ -231,7 +231,7 @@ Then \textbf{Search (2)} Ability, Spell, or Artifact deck.}
   \begin{minipage}[t]{0.47\textwidth}
     \vspace{0pt}
     \centering
-    \textbf{Witch Hut}\medskip
+    \phantom{j}\textbf{Witch Hut}\par
     \shadowimage[width=\linewidth]{\images/witch_hut.jpg}
     \caption{\small Category: \textbf{Visitable}\\
       \textbf{Choose one}: Remove an Ability card from your hand OR look at the top card of the Ability deck and put that card into your hand or into the Ability deck discard pile.}
@@ -242,7 +242,7 @@ Then \textbf{Search (2)} Ability, Spell, or Artifact deck.}
   \begin{minipage}[t]{0.47\textwidth}
     \vspace{0pt}
     \centering
-    \textbf{Obelisk}\medskip
+    \phantom{j}\textbf{Obelisk}\par
     \shadowimage[width=\linewidth]{\images/obelisk.jpg}
     \caption{\small Category: \textbf{Flaggable}\\
       The Obelisk's effects vary depending on the scenario.
@@ -251,7 +251,7 @@ Then \textbf{Search (2)} Ability, Spell, or Artifact deck.}
   \begin{minipage}[t]{0.47\textwidth}
     \vspace{0pt}
     \centering
-    \textbf{Star Axis}\medskip
+    \phantom{j}\textbf{Star Axis}\par
     \shadowimage[width=\linewidth]{\images/star_axis.jpg}
     \caption{\small Category: \textbf{Flaggable}\\
       You may Remove one of your Statistic cards from your hand and replace it with an \textbf{Empowered} one of the same type.
@@ -263,7 +263,7 @@ Then \textbf{Search (2)} Ability, Spell, or Artifact deck.}
   \begin{minipage}[t]{0.47\textwidth}
     \vspace{0pt}
     \centering
-    \textbf{Hill Fort}\medskip
+    \phantom{j}\textbf{Hill Fort}\par
     \shadowimage[width=\linewidth]{\images/hill_fort.jpg}
     \caption{\small Category: \textbf{Visitable}\\
       You may immediately Reinforce one of your \includesvg[height=8px]{\svgs/bronze.svg} or \includesvg[height=8px]{\svgs/silver.svg} units.
@@ -272,7 +272,7 @@ Then \textbf{Search (2)} Ability, Spell, or Artifact deck.}
   \begin{minipage}[t]{0.47\textwidth}
     \vspace{0pt}
     \centering
-    \textbf{Prison}\medskip
+    \phantom{j}\textbf{Prison}\par
     \shadowimage[width=\linewidth]{\images/prison.jpg}
     \caption{\small Category: \textbf{Visitable}\\
       Gain a Secondary Hero.
@@ -286,7 +286,7 @@ Then \textbf{Search (2)} Ability, Spell, or Artifact deck.}
     \vspace{0pt}
     \captionsetup{singlelinecheck=off}
     \centering
-    \textbf{Scholar}\par\medskip
+    \phantom{j}\textbf{Scholar}\par
     \shadowimage[width=\linewidth]{\images/scholar.jpg}
     \caption[scholar they]{\small Category: \textbf{Visitable}\\
       Roll 1 Attack die.


### PR DESCRIPTION
Finally found a workaround for this.

Before:
![image](https://github.com/Heegu-sama/Homm3BG/assets/5611195/40a70a2a-1fe8-4adf-bc92-5deea5a1ee66)

After:
![image](https://github.com/Heegu-sama/Homm3BG/assets/5611195/a7fe9416-8978-4c62-8325-bc35f279b0ef)
