### PR TITLE
Add gameplay examples

### DIFF
--- a/sections/combat.tex
+++ b/sections/combat.tex
@@ -239,3 +239,29 @@ Any differences to the above will be described in any given Scenario's own rules
   \centering
   \includegraphics[width=\textwidth]{\art/sharpshooter.jpg}
 \end{figure*}
+
+\clearpage
+
+\begin{multicols}{2}
+\textit{Sandro's Zombies are about to attack Catherine's Griffins.
+As Sandro announces the attack, both players now have a chance to modify the attack or defense of their own Unit by playing any number of \includesvg[height=10px]{\svgs/instant.svg} cards that increase an attacking Unit's \includesvg[height=10px]{\svgs/attack.svg} or a defending Unit's \includesvg[height=10px]{\svgs/defense.svg}.}\par
+\textit{Sandro decides to play a +1 Attack Card, increasing the Zombies' attack from 2 to 3.
+Catherine responds by playing a +1 Defense Card, increasing the Griffins' defense from 0 to 1.
+They would both be permitted to play any amount of additional cards in any order, but they decide to stop after playing these cards.}\par
+\textit{After all cards for the attack have been played, the Attack Die is thrown to further modify the amount of damage the attacking Unit deals.
+Sandro throws a +1.
+This increases the Zombies' attack from 3 to 4, which is then reduced by the Griffins' defense of 1. Therefore, 3 damage \includesvg[height=10px]{\svgs/damage.svg} is placed on the Griffins. Since they have a HP \includesvg[height=10px]{\svgs/health_points.svg} of 4, they are not removed from the Combat.}\par
+\textit{The Griffins do not have a black cube on them, therefore they now start a Retaliation Attack.
+The cube would now normally be placed on them, however their Special \includesvg[height=10px]{\svgs/unit_retaliate.svg} Ability indicates that they may Retaliate any number of times so the cube is not placed.}\par
+\textit{Relatiation Attacks work identically to a normal attack, with the exception that they do not cause another Retaliation Attack.
+Therefore, both players are now allowed to modify the statistics of their units again.
+The previously played Attack and Defense cards no longer have any effect.}
+
+\bigbreak
+
+\textit{Alamar casts a Magic Arrow against Sandro's pack of Skeletons, Empowering \includesvg[height=10px]{\svgs/empower.svg} the spell by two with the Expert  Effect \includesvg[height=10px]{\svgs/expert.svg} of a Power Card.
+The Skeletons take 3 damage \includesvg[height=10px]{\svgs/damage.svg} from the spell.
+Their defense \includesvg[height=10px]{\svgs/defense.svg} of 1 does not reduce the damage, because it only applies against attacks.
+The Skeletons have a HP \includesvg[height=10px]{\svgs/health_points.svg} of only 2, so they are now turned to their "Few" side and 1 leftover damage \includesvg[height=10px]{\svgs/damage.svg} is placed on them.}
+
+\end{multicols}

--- a/sections/deckbuilding.tex
+++ b/sections/deckbuilding.tex
@@ -7,7 +7,7 @@ All players have a unique deck which represents their Main Hero's Abilities and 
 Decks may contain Statistic, Ability, Spell, Artifact and the Main Hero's Specialty Cards.
 
 Each player's deck starts with 9 cards, built during the game's set up.
-Game components may refer to this deck as your \textbf{Deck of Might and Magic}, in this rule book this is shorthanded to \textbf{Your Deck}.
+This deck is called your \textbf{Deck of Might \& Magic}. From this point in this rule book this is \textbf{shorthanded} to \textbf{Your Deck}.
 \subsection*{General Card Rules}
 \begin{enumerate}
   \item Cards can be played \textbf{only on your turn}, or in a \hyperlink{Combat}{Combat} involving your \textbf{Main Hero}.
@@ -108,3 +108,15 @@ While many Specialty Cards have effects which resemble Spell Cards, Specialty Ca
 \end{center}
 
 \end{multicols*}
+
+\clearpage
+
+\begin{multicols}{2}
+
+\textit{Deemer the Warlock has built a Mage Guild during the previous Game Round, enabling him to now use his Spell Book Token to purchase additional spells.
+He spends the token and pays the cost indicated on his Town Board, allowing him to \textbf{Search (2)} the Spell Deck.}\par
+\textit{He now has the choice of either gaining the top card of the Spell Card discard pile, or drawing the top two cards of the Spell Deck and gaining one of them.
+He is not interested in gaining the Spell Curse, which is on top of the discard pile, and instead decides to draw  two cards – a Magic Arrow and a Fireball.
+He decides to keep the Fireball, placing it into his hand and discarding the Magic Arrow into the Spell Discard Pile.}
+
+\end{multicols}

--- a/sections/heroes.tex
+++ b/sections/heroes.tex
@@ -144,3 +144,16 @@ Search (2) the Ability Deck.
   \centering
   \includegraphics[width=0.9\linewidth]{\art/dread_knight.jpg}
 \end{figure*}
+
+\clearpage
+
+\begin{multicols}{2}
+
+\textit{Catherine the Knight begins her turn. She starts by drawing cards from her Deck of Might \& Magic up to her Hand Limit \includesvg[height=10px]{\svgs/hand.svg} of 5, since her Main Hero is Level 3.
+She had used all of her cards during the previous Game Round, so she does not have to opportunity to discard any cards before drawing up to her Hand Limit.}\par
+\textit{She then spends her Build Token to construct the \includesvg[height=10px]{\svgs/golden.svg} Dwelling, and then her Population Token to \hyperlink{Units}{Recruit} the \includesvg[height=10px]{\svgs/golden.svg} Unit Champions.
+She is allowed to do this, as she had previously built the prerequisite lower level Dwellings (\includesvg[height=10px]{\svgs/bronze.svg} and \includesvg[height=10px]{\svgs/silver.svg}) and has enough \hyperlink{Resources}{Resources} to both Build the Dwelling and to Recruit the Champions.}\par
+\textit{Now prepared for a coming battle, she spends a Movement Point to move her Main Hero to an adjacent field currently occupied by Sandro the Necromancer, an enemy Main Hero.}\par
+\textit{As Catherine declares her intent to start \hyperlink{Combat}{Combat}, Sandro still now has an opportunity to spend any of his Town, Population and/or Spell Book Tokens to also strengthen his army before Combat begins.}
+
+\end{multicols}

--- a/sections/map_elements.tex
+++ b/sections/map_elements.tex
@@ -63,3 +63,20 @@ You may always rotate Map Tiles when placing them.\par
   \centering
   \includegraphics[width=\textwidth]{\images/placement.png}
 \end{figure*}
+
+\clearpage
+
+\begin{multicols}{2}
+    
+\textit{Sandro the Necromancer wants to capture an adjacent \hyperlink{Mines}{Mine} by Flagging it.
+He spends a Movement Point to move onto the Mine, which begins \hyperlink{Combat}{Combat} against Neutral Units since the Field has a \hyperlink{Difficulty}{Difficulty Rating} and has not been previously Flagged by any player.}\par
+\textit{His current hand consists of a Power card, a Magic Arrow, Haste, and a Town Portal.
+During the Combat, he casts the Magic Arrow, and Empowers \includesvg[height=10px]{\svgs/empower.svg} it with Haste's bottom ability and the Power Card's Expert Effect \includesvg[height=10px]{\svgs/expert.svg}.}
+\textit{He is allowed to do this, as he is Level 2 and can thus use one \includesvg[height=10px]{\svgs/expert.svg} each Game Round.
+The Combat lasts for only one round, so he would not have been able to cast both Magic Arrow and Haste, since players are limited to playing only one Spell Card per Combat Round.}\par
+\textit{Sandro wins the Combat and Flags the Mine by placing one of his Faction Cubes on it.
+Flagging this particular Mine increases his Gold \includesvg[height=10px]{\svgs/gold.svg} production by 5, and he also immediately gains the Mine's production value of 5 \includesvg[height=10px]{\svgs/gold.svg} as he was the first player to Flag it.}\par
+\textit{Afterwards, Sandro wants to move back to a previously Flagged Settlement by casting the Town Portal still left in his hand.
+He would love to Empower this Spell too in order to gain additional Movement Points after casting it, but is unable to do so as he has no other cards left in his hand that could potentially Empower it.}
+    
+\end{multicols}

--- a/sections/player_turns.tex
+++ b/sections/player_turns.tex
@@ -2,7 +2,7 @@
 
 \begin{multicols*}{2}
 
-At the start of a player's turn, that player refreshes their hand of cards from their Deck following two steps in order:
+At the start of a player's turn, that player refreshes their hand of cards from their Deck of Might \& Magic following two steps in order:
 \begin{itemize}
   \item Discard any number of cards from your hand.
 If your current hand exceeds your Hand Limit \includesvg[height=10px]{\svgs/hand.svg}, you must discard down to at least your Hand Limit.

--- a/sections/setup.tex
+++ b/sections/setup.tex
@@ -42,7 +42,7 @@ This section will guide you through the process of setting up a Scenario from th
   \item If your main hero is a Hero of Might \includesvg[height=10px]{\svgs/might.svg}, add 1 copy of the Magic Arrow Spell to your deck, and if they’re a Hero of Magic \includesvg[height=10px]{\svgs/magic.svg}, add 2 of these Spells to your deck.
   \item Add your Hero's \hyperlink{Ability}{Ability} and Level 1 \hyperlink{Specialty}{Specialty} Cards to your Starting Deck.
   \item Shuffle your Starting Deck and place it face down next to your Hero Card.
-    The deck is now ready for play.
+    This deck is your Main Hero's \textbf{Deck of Might \& Magic}, and is now ready for play.
   \item Sort the ability, artifact, and spell Cards into 3 face down decks (including any unused Magic Arrow Spells) and shuffle them.
     From each of these decks, take the top Card and place it face up next to its Deck, creating 3 separate discard piles.
   \item Choose the Scenario's \hyperlink{Difficulty}{Difficulty} and take the corresponding Starting Bonus(es).


### PR DESCRIPTION
Added three examples of playing the game. They are currently placed just at the end of the combat and map elements sections, waiting to be slotted into an appropriate place with images.