### PR TITLE
Fixed more capitalization inconsistencies

### DIFF
--- a/sections/all_map_locations.tex
+++ b/sections/all_map_locations.tex
@@ -8,7 +8,7 @@ The vast majority of Fields have useful iconography that clearly communicates th
 On the right is a screenshot of the back of the rule book that explains these.
 If a Field has any combination of these icons and is not described in detail later, then that Field is either \textbf{Visitable} or \textbf{Flaggable} and its only effect is indicated by these icons.\par
 Revisitable Fields do not have an icon that indicates them to be such.
-For this reason all revisitable Fields are pictured and described individually.
+For this reason all Revisitable Fields are pictured and described individually.
 The \includegraphics[height=0.8\baselineskip]{\images/revisitable.png} symbol is on almost all Flaggable Fields, with the major exception of Settlements.
 Rules for Flagging Mines, Settlements and Towns are on the next page followed by descriptions of Revisitable and unique Fields marked with a question mark.\par
 Random Towns and War Machine Factories are explained above.
@@ -32,7 +32,7 @@ Flagging a Town also gives you a Faction Cube from its original owner.
 Otherwise, Flagging a Town does not affect its original owner in any way.
 They do not lose access to their Town board or its functions.
 You also do not gain access to their Town board or Faction Units, unlike in the video game.
-You can \hyperlink{Town}{pay gold} to defend towns with your Units if you Hero is not there when it is attacked.
+You can \hyperlink{Town}{pay Gold} to defend towns with your Units if you Hero is not there when it is attacked.
 
 \begin{center}
   \shadowimage[width=\linewidth]{\images/core_towns.jpg}
@@ -46,15 +46,15 @@ If you are the first one to flag a mine, it also immediately provides you with i
 
 \begin{center}
   \shadowimage[width=0.6\linewidth]{\images/mine_example.png}\\
-  \textit{A mine that produces valuables, guarded by level 3 neutrals.
-    The first player to flag this Field would immediately gain one valuable in addition to increasing their valuables income.
+  \textit{A mine that produces Valuables, guarded by Level 3 neutrals.
+    The first player to flag this Field would immediately gain one valuable in addition to increasing their Valuables income.
     All Mines have the \includegraphics[height=0.8\baselineskip]{\images/revisitable.png} symbol.
   }
 \end{center}
 
 \textbf{Settlements} function similarly to both Towns and Mines.
 They act as a spawn point for Secondary Heroes, and as a place for Main Heroes to move to when defeated.
-You may also \hyperlink{Town}{pay gold} to defend Settlements with Units.
+You may also \hyperlink{Town}{pay Gold} to defend Settlements with Units.
 When you flag a Settlement, you choose whether to increase your \includesvg[height=10px]{\svgs/gold.svg}, \includesvg[height=10px]{\svgs/building_materials.svg} or \includesvg[height=10px]{\svgs/valuablegreater.svg} income by one space.
 As with Mines, if you are the first player to flag a settlement, you immediately gain resources equal to that increase in production.
 Mark the settlement with an appropriate Resource Token to show which resource it produces.
@@ -94,7 +94,7 @@ Do not place any Resource Tokens on the Settlement if you choose to Reinforce.
       \includesvg[height=8px]{\svgs/pay_v2.svg}
       3 \includesvg[height=8px]{\svgs/gold.svg}
       to Remove 1 Statistic card from your hand or Discard Pile and replace it with any other Statistic card.
-      You may do this twice per visit.}
+      You may do this twice per Visit.}
   \end{minipage}\hfill
   \begin{minipage}[t]{0.47\textwidth}
     \vspace{0pt}
@@ -168,7 +168,7 @@ The effects of these Fields are only indicated by a question mark on their tiles
   \begin{minipage}[t]{0.47\textwidth}
     \vspace{0pt}
     \centering
-    \textbf{Tree Of Knowledge}\par
+    \textbf{Tree of Knowledge}\par
     \shadowimage[width=\linewidth]{\map_locations/tree_of_knowledge.jpg}
     \caption{\small Category: \textbf{Visitable}\\You may
       \includesvg[height=8px]{\svgs/pay_v2.svg}
@@ -206,7 +206,7 @@ The effects of these Fields are only indicated by a question mark on their tiles
   \begin{minipage}[t]{0.47\textwidth}
     \vspace{0pt}
     \centering
-    \phantom{j}\textbf{Market Of Time}\par
+    \phantom{j}\textbf{Market of Time}\par
     \shadowimage[width=\linewidth]{\map_locations/market_of_time.jpg}
     \caption{\small Category: \textbf{Visitable}\\ Remove one card from your hand.
 Then \textbf{Search (2)} Ability, Spell, or Artifact deck.}

--- a/sections/combat.tex
+++ b/sections/combat.tex
@@ -49,7 +49,7 @@ Unit setup when fighting \textbf{other players}:
 The following terms are used in this rule book and by the Unit and other cards to describe effects and elements during combat:\par
 \textbf{Attacking Playe}r – The player who started the Combat by moving their Hero.\par
 \textbf{Defending Player} – The player whom Combat was started against.\par
-\textbf{Activation} – A Unit activates when it is next in the Initiative order.\par
+\textbf{Activation} – A Unit Activates when it is next in the Initiative order.\par
 \textbf{Adjacent Unit} – A Unit is directly adjacent to another if it is one space away in a cardinal direction (nondiagonal).\par
 \textbf{Combat Round} – A full cycle of all Units of each player being Activated.\par
 \textbf{Combat Obstacles} – Every card placed on the Combat Board counts as a Combat Obstacle.
@@ -60,15 +60,15 @@ add the result to the unit's attack value.\par
 \textbf{\hypertarget{Retaliate}{Retaliation Attack}} – If a unit survives an attack by an adjacent Unit, it performs an attack back on that Unit.
 Each Unit can perform only 1 Retaliation Attack per Combat Round.
 Retaliation Attacks function identically to normal attacks, but they cannot cause another Retaliation Attack.
-Mark Units which have performed a Retaliation Attack this round with a black cube.\par
+Mark Units which have performed a Retaliation Attack this Round with a black cube.\par
 \textbf{Paralysis} \includesvg[height=10px]{\svgs/paralysis.svg} – Effects which paralyze a Unit place the Paralysis Token on them.
 A paralyzed Unit \textbf{skips its next Activation} and removes the token instead.
 If it is \textbf{attacked or takes any damage} before that time, \textbf{remove the Paralysis Token} from that unit.\par
 \textbf{\hypertarget{Defend}{Defend}} \includesvg[height=10px]{\svgs/defense.svg} – When a Unit with a Defense Token is attacked, make another roll with the attack die
 after the initial attack roll.
-If you roll a “+1”, the defending Unit gains an extra 1 defense for this attack.
+If you roll a “+1”, the defending Unit gains an extra 1 Defense for this attack.
 If a Unit has a Defense Token at the start of its activation, discard it.
-The Unit cannot take another defense action during that activation.
+The Unit cannot take another Defense action during that activation.
 
 \subsection*{\hypertarget{CombatCards}{Using Cards During Combat}}
 You may only use \textbf{one Spell per Combat Round}.
@@ -76,7 +76,7 @@ Other card types can be used as many times as you want to.
 Ongoing \includesvg[height=10px]{\svgs/ongoing.svg} and \includesvg[height=10px]{\svgs/activation.svg} Activate effects can be used only when Activating one of your Units and before it attacks.
 Ongoing effects last until end of Combat or if the effect on the card is used up.
 Instant \includesvg[height=10px]{\svgs/instant.svg} Cards may be played at any time except between rolling the Combat Die and resolving damage unless otherwise stated.
-Instant Cards which increase a unit's statistics \textbf{last only for the duration of the currently activated Unit's next attack}.
+Instant Cards which increase a unit's statistics \textbf{last only for the duration of the currently Activated Unit's next attack}.
 \subsection*{\hypertarget{Timelimit}{Combat Time Limits}}
 Combat against Neutral Units has a time limit of \textbf{one Combat Round}.
 If the player cannot win the Combat before the end of the current Combat Round, they must either \hyperlink{Endcombat}{Retreat} or spend 1 MP from the Hero that started the combat in order to play another Combat Round.\par
@@ -131,10 +131,10 @@ The defender also gains the Arrow Tower Unit Card which is placed next to the Co
 
 \subsection*{Combat Round Structure}
 Combat is divided into Rounds, during which all of the Units participating in that Combat \textbf{Activate once} in Initiative order.
-After each Unit has activated, a new Combat Round begins.
+After each Unit has Activated, a new Combat Round begins.
 Combat lasts until all Units on one side are eliminated, a player has to \textbf{retreat} when fighting Neutral Units, or a player \textbf{Surrenders} to another player.
 
-Structure of a combat round:
+Structure of a combat Round:
 \begin{itemize}
   \item Players Activate their Units in decreasing order of Unit \hyperlink{Initiative}{Intiative}.
   \item When a unit Activates, place a Faction Cube on it to indicate it has been Activated this Combat Round.
@@ -143,10 +143,10 @@ Structure of a combat round:
   In Neutral Combat, the Neutral Enemy units cannot defend, even when controlled by another player.
   \item Before a Unit attacks, both players may \hyperlink{CombatCards}{play cards}. Cards are resolved in the order in which players decide to play them.
   \item After a Unit's attack has been declared and all cards have been played that the players wish to play, roll the Combat Die.
-    Modify the attacking Unit's attack by the die's result, then reduce it by the defending Unit's defense, and finally deal the rest as \hyperlink{HP}{damage} to the defending Unit.
-  \item If the defending Unit was adjacent to the attacker, it \hyperlink{Retaliate}{retaliates} if it hasn't done so this round.
-  \item Keep activating Units until they've all been activated once.
-After the last Unit's activation, the combat round ends.
+    Modify the attacking Unit's attack by the die's result, then reduce it by the defending Unit's Defense, and finally deal the rest as \hyperlink{HP}{damage} to the defending Unit.
+  \item If the defending Unit was adjacent to the attacker, it \hyperlink{Retaliate}{retaliates} if it hasn't done so this Round.
+  \item Keep activating Units until they've all been Activated once.
+After the last Unit's activation, the combat Round ends.
 \end{itemize}
 \subsection*{\hypertarget{Endcombat}{End Of Combat}}
 Combat can end in the following ways:
@@ -245,16 +245,16 @@ Any differences to the above will be described in any given Scenario's own rules
 
 \begin{multicols*}{2}
 \textit{Sandro's Zombies are about to attack Catherine's Griffins.
-As Sandro announces the attack, both players now have a chance to modify the attack or defense of their own Unit by playing any number of \includesvg[height=10px]{\svgs/instant.svg} cards that increase an attacking Unit's \includesvg[height=10px]{\svgs/attack.svg} or a defending Unit's \includesvg[height=10px]{\svgs/defense.svg}.}\par
+As Sandro announces the attack, both players now have a chance to modify the attack or Defense of their own Unit by playing any number of \includesvg[height=10px]{\svgs/instant.svg} cards that increase an attacking Unit's \includesvg[height=10px]{\svgs/attack.svg} or a defending Unit's \includesvg[height=10px]{\svgs/defense.svg}.}\par
 \textit{Sandro decides to play a +1 Attack Card, increasing the Zombies' attack from 2 to 3.
-Catherine responds by playing a +1 Defense Card, increasing the Griffins' defense from 0 to 1.
+Catherine responds by playing a +1 Defense Card, increasing the Griffins' Defense from 0 to 1.
 They would both be permitted to play any amount of additional cards in any order, but they decide to stop after playing these cards.}\par
 
 \includegraphics[width=\linewidth]{\examples/zombies_attack_griffins.png}
 
 \textit{After all cards for the attack have been played, the Attack Die is thrown to further modify the amount of damage the attacking Unit deals.
 Sandro throws a +1.
-This increases the Zombies' attack from 3 to 4, which is then reduced by the Griffins' defense of 1. Therefore, 3 damage \includesvg[height=10px]{\svgs/damage.svg} is placed on the Griffins. Since they have a HP \includesvg[height=10px]{\svgs/health_points.svg} of 4, they are not removed from the Combat.}\par
+This increases the Zombies' attack from 3 to 4, which is then reduced by the Griffins' Defense of 1. Therefore, 3 damage \includesvg[height=10px]{\svgs/damage.svg} is placed on the Griffins. Since they have a HP \includesvg[height=10px]{\svgs/health_points.svg} of 4, they are not removed from the Combat.}\par
 \textit{The Griffins do not have a black cube on them, therefore they now start a Retaliation Attack.
 The cube would now normally be placed on them, however their Special \includesvg[height=10px]{\svgs/unit_retaliate.svg} Ability indicates that they may Retaliate any number of times so the cube is not placed.}\par
 \textit{Relatiation Attacks work identically to a normal attack, with the exception that they do not cause another Retaliation Attack.

--- a/sections/deckbuilding.tex
+++ b/sections/deckbuilding.tex
@@ -37,7 +37,7 @@ This deck is called your \textbf{Deck of Might \& Magic}. From this point in thi
 
 All Ability and Statistic cards have a Basic Effect and a stronger Expert \includesvg[height=10px]{\svgs/expert.svg} Effect, which is shown below the Basic Effect.
 Whenever you play an Ability or Statistic card, you must choose which effect you are using.
-The number of \includesvg[height=10px]{\svgs/expert.svg} Effects you can use each round is limited by your Main Hero's \hyperlink{Level}{Level}.
+The number of \includesvg[height=10px]{\svgs/expert.svg} Effects you can use each Round is limited by your Main Hero's \hyperlink{Level}{Level}.
 Track the number of uses you have in any suitable manner, such as by moving Black Cubes on and off your Hero Card.\par
 \bigskip
 
@@ -48,9 +48,9 @@ When a non-Necropolis player draws one from the Ability Deck, they may either di
 Non-Necropolis players \textbf{cannot use} Faction Specific Cards from their hand in any way besides for effects that discard them.
 
 \subsection*{Artifact Cards}
-Artifact Cards are divided into 3 levels: Minor, Major, and Relic.
-These levels relate to the overall power of the Card and may be referenced when resolving certain effects or during Scenario setup.
-Otherwise, all Artifact Cards are normally shuffled together regardless of their level.
+Artifact Cards are divided into 3 Levels: Minor, Major, and Relic.
+These Levels relate to the overall Power of the Card and may be referenced when resolving certain effects or during Scenario setup.
+Otherwise, all Artifact Cards are normally shuffled together regardless of their Level.
 Artifacts are gained through map exploration.\par
 Artifacts can be \hyperlink{Trading}{traded} in Alliance and Cooperative Scenarios.\par
 \includegraphics[width=\linewidth]{\cards/artifact.png}
@@ -60,7 +60,7 @@ Artifacts can be \hyperlink{Trading}{traded} in Alliance and Cooperative Scenari
 
 Spell Cards have three possible primary effects.
 Using the topmost, basic version of the Spell has no additional costs.
-To access the other effects, you may \textbf{Empower} a spell by paying the indicated cost (3) to get a more powerful outcome (4).
+To access the other effects, you may \textbf{Empower} a Spell by paying the indicated cost (3) to get a more powerful outcome (4).
 You may pay this cost by playing other cards for their Empower \includesvg[height=10px]{\svgs/empower.svg} effect before casting the Spell.
 All Spell Cards also have an alternative bottom (5) \includesvg[height=10px]{\svgs/empower.svg} effect.\par
 
@@ -99,7 +99,7 @@ While many Specialty Cards have effects which resemble Spell Cards, Specialty Ca
 \begin{center}
   \shadowimage[width=0.6\linewidth]{\cards/specialty.jpg}\\
   \medskip
-  \scriptsize\textit{A level 4 Specialty Card, belonging to Catherine the Knight.}
+  \scriptsize\textit{A Level 4 Specialty Card, belonging to Catherine the Knight.}
 \end{center}
 
 \subsection*{Example}

--- a/sections/expansion_content.tex
+++ b/sections/expansion_content.tex
@@ -7,7 +7,7 @@
 Most expansions have effects which refer to Schools of Magic.
 All Spell Cards belong to one School: either Air, Fire, Earth or Water.
 When casting the \textbf{Magic Arrow Spell}, you must select which School it belongs to.
-\textbf{Hero specialty cards are not spells} even though some of them have a School of Magic.
+\textbf{Hero specialty cards are not Spells} even though some of them have a School of Magic.
 Spells with four School symbols on them are \textbf{Expert Spells}, which may be referred to by certain effects.
 
 \columnbreak
@@ -47,10 +47,10 @@ Spells with four School symbols on them are \textbf{Expert Spells}, which may be
   \includegraphics[width=0.5\linewidth]{\art/land_mine.png}
 \end{center}
 
-\subsection*{War machines}
+\subsection*{War Machines}
 Added by the Rampart expansion.
-War Machines are permanent cards that can be bought at either a Trading Post or a War Machine Factory.
-If you buy one at the Trading Post, \textbf{you cannot use} any of the other normal functions of that Field during that visit.
+War Machines are permanent Cards that can be bought at either a Trading Post or a War Machine Factory.
+If you buy one at the Trading Post, \textbf{you cannot use} any of the other normal functions of that Field during that Visit.
 War machines are also more expensive at the Trading Post.\par
 \medskip
 \begin{minipage}[h]{\linewidth}
@@ -130,7 +130,7 @@ Any cards which were revealed as a part of resolving an Event should be shuffled
 \subsection*{Summoning}
 Some cards from the Inferno expansion may Summon Units during Combat.
 Place the summoned Unit adjacent to the summoning Unit.
-Summoned Units Activate in the round they were summoned if their initiative is lower or equal to the Initiative of the currently Activated Unit.
+Summoned Units Activate in the Round they were summoned if their Initiative is lower or equal to the Initiative of the currently Activated Unit.
 Otherwise, treat them as if they already activated this Combat Round.
 After Combat, unless stated otherwise, the Summoned Units are added to your Unit Deck.
 
@@ -149,7 +149,7 @@ When this Field is revealed, all players roll 2 \includesvg[height=10px]{\svgs/r
 The highest roller chooses an unused Faction.
 The random Town is defended by Units from that Faction.
 They have a pack of bronze, two packs of silver, and two "fews" of gold Units.
-Flagging it increases gold production by 10, which is also gained immediately if you are the first to flag it.
+Flagging it increases Gold production by 10, which is also gained immediately if you are the first to Flag it.
 
 \bigskip
 

--- a/sections/heroes.tex
+++ b/sections/heroes.tex
@@ -126,7 +126,7 @@ The Level Tracker on your Hero Card shows the following information:
 \item Your current Hand Limit \includesvg[height=10px]{\svgs/hand.svg}.
 \item The number of \hyperlink{Ability}{Expert Effects} \includesvg[height=10px]{\svgs/expert.svg} you may use during a Round.
 \item At which Levels your Main Hero must \hyperlink{Playerdecks}{\textbf{Search}} for a new \hyperlink{Ability}{Ability Card} or gain a \hyperlink{Specialty}{Specialty Card}.
-Level numbers written in gold on the Level Tracker (\includesvg[height=10px]{\svgs/level1.svg}, \includesvg[height=10px]{\svgs/level4.svg} and \includesvg[height=10px]{\svgs/level6.svg}) give you a Specialty Card, while silver levels (2, 3, 5, 7) give you an Ability Card.
+Level numbers written in gold on the Level Tracker (\includesvg[height=10px]{\svgs/level1.svg}, \includesvg[height=10px]{\svgs/level4.svg} and \includesvg[height=10px]{\svgs/level6.svg}) give you a Specialty Card, while silver Levels (2, 3, 5, 7) give you an Ability Card.
 \end{itemize}
 List of all effects:
 \begin{itemize}
@@ -151,7 +151,7 @@ Search (2) the Ability Deck.
 \textit{Catherine the Knight begins her Turn. She starts by drawing cards from her Deck of Might \& Magic up to her Hand Limit \includesvg[height=10px]{\svgs/hand.svg} of 5, since her Main Hero is Level 3.
 She had used all of her Cards during the previous Game Round, so she does not have to opportunity to discard any Cards before drawing.}\par
 \textit{She then spends her Build Token to construct the \includesvg[height=10px]{\svgs/golden.svg} Dwelling, and then her Population Token to \hyperlink{Units}{Recruit} the \includesvg[height=10px]{\svgs/golden.svg} Unit Champions.
-She is allowed to do this, as she had previously built the prerequisite lower level Dwellings (\includesvg[height=10px]{\svgs/bronze.svg} and \includesvg[height=10px]{\svgs/silver.svg}) and has enough \hyperlink{Resources}{Resources} to both Build the Dwelling and to Recruit the Champions.}\par
+She is allowed to do this, as she had previously built the prerequisite lower Level Dwellings (\includesvg[height=10px]{\svgs/bronze.svg} and \includesvg[height=10px]{\svgs/silver.svg}) and has enough \hyperlink{Resources}{Resources} to both Build the Dwelling and to Recruit the Champions.}\par
 \textit{Now prepared for a coming battle, she spends a Movement Point to move her Main Hero to an adjacent Field currently occupied by Sandro the Necromancer, an enemy Main Hero.}\par
 
 \includegraphics[width=\linewidth]{\examples/catherine_attacks_sandro.png}

--- a/sections/map_elements.tex
+++ b/sections/map_elements.tex
@@ -22,8 +22,8 @@ Starting (I) Tiles are the easiest while Center (VI-VII) Tiles are the most diff
 \subsection*{Map Tile Anatomy}
 Each Map Tile is divided into 7 separate \textbf{Fields} that your Heroes can \textbf{Visit}.
 When a Hero moves to a Field, they must immediately Visit it, or
-first start a \hyperlink{Combat}{Combat} against the enemies guarding it before visiting.
-Empty Fields do nothing when visited.
+first start a \hyperlink{Combat}{Combat} against the enemies guarding it before Visiting.
+Empty Fields do nothing when Visited.
 Solid yellow lines on a Field's edge cannot be passed through.
 \hyperlink{Difficulty}{Roman numerals} written on a Field indicate that the Field is guarded by neutral enemies that must be fought to Visit it.\par
 
@@ -38,7 +38,7 @@ There are three categories of Visitable Fields:
   \item \textbf{Visitable} – Once you Visit this field, place a Black Cube on it.
     Treat it as an Empty Field as long as it has a Black Cube.
   \item \textbf{Flaggable} – These Fields can be directly captured by players and provide passive benefits.
-    When you visit one, place a Faction Cube on it and gain a benefit.
+    When you Visit one, place a Faction Cube on it and gain a benefit.
     Enemy Heroes who Visit your Flagged Fields will replace your Cube with theirs to \textbf{steal} the Field’s effects.
     Allied Heroes treat Flagged Fields \textbf{as if they were empty}.
   \item \textbf{Revisitable} – You can Visit this Field multiple times.

--- a/sections/other_rules.tex
+++ b/sections/other_rules.tex
@@ -10,7 +10,7 @@ You may also \textbf{Remove cards} from your hand at the trading post to gain 1 
 In \textbf{Alliance} and \textbf{Cooperative} Scenarios, players are allowed to trade Resources and cards following these rules:
 \begin{itemize}
   \item In Alliance Scenarios, allies may trade Resources freely at any time on their turns except during Combat.
-  \item In Cooperative Scenarios, Resources may be given to other players when visiting a Trading Post.
+  \item In Cooperative Scenarios, Resources may be given to other players when Visiting a Trading Post.
   \item In both Scenario types, allies may trade \textbf{Spell} and \textbf{Artifact} cards in any mix if they have heroes on adjacent Fields.
     Only \textbf{cards from their hands} may be traded and you must give and receive an equal amount of cards.
 \end{itemize}

--- a/sections/player_turns.tex
+++ b/sections/player_turns.tex
@@ -19,7 +19,7 @@ A player can use Movement Actions \textbf{only during their own Turn}.\par
 For every 1 MP spent, you can perform one of the following Actions:
 \begin{itemize}
   \item Move a Hero 1 Field in any direction.
-  \item \hyperlink{Categories}{Re-visit} a Field where your Hero is in.
+  \item \hyperlink{Categories}{Revisit} a Field where your Hero is in.
   \item \hyperlink{Timelimit}{Continue Combat} against Neutral Units for 1 additional Combat Round.
   \item \hyperlink{Placing}{Discover a face down Map Tile} if your Hero is on a Field next to that Tile.
   \item Place a new Map Tile from your pool of Far (II-III) Map Tiles.
@@ -37,7 +37,7 @@ Mark the amount of MP you have used by flipping your Movement Tokens over to the
 If a player has both a Main and a \hyperlink{Secondary}{Secondary Hero}, track their MP separately.
 Heroes can spend MP in any order.\par
 Allied Heroes can move through each other but cannot stop their movement in the same Field.
-When you move through a Field with an allied Hero, do not \hyperlink{Categories}{visit} the Field that the allied Hero is standing on.
+When you move through a Field with an allied Hero, do not \hyperlink{Categories}{Visit} the Field that the allied Hero is standing on.
 In the unlikely situation that two allied Heroes are forced onto the same Field, you must use your next MP to move one of them away from that Field.\par
 \textbf{Important}: Whenever you are instructed to gain (additional) MP, sometimes shorthanded with the symbol \includesvg[height=10px]{\svgs/movement.svg}, that MP persists for \textbf{only the Turn it was gained on}.
 In the unlikely situation that two allied Heroes are forced onto the same Field, you must use your next MP to move one of them away from that Field.

--- a/sections/round_structure.tex
+++ b/sections/round_structure.tex
@@ -13,7 +13,7 @@ Perform the following steps at the start of every Round except the first one:
 \end{itemize}
 Then, depending on the current Round number, players either gain Resources or resolve an Astrologers Proclaim Card:
 \begin{itemize}
-  \item Odd-numbered rounds are Resource Rounds.
+  \item Odd-numbered Rounds are Resource Rounds.
     All players gain income from the \hyperlink{Mines}{Buildings, Settlements, and Mines} they control.
     Skip this step during the first Round.
   \item Even-numbered Rounds are Astrologers' Rounds.

--- a/sections/setup.tex
+++ b/sections/setup.tex
@@ -27,7 +27,7 @@ This section will guide you through the process of setting up a Scenario from th
     \item[l)]3 × Movement Tokens
   \end{itemize}
   \item Place one of your Faction Cubes on the first space of the Level Tracker found on the Hero Card (Represented by a “1”).
-    Your hero is now level 1.
+    Your hero is now Level 1.
   \item Set the game up according to the number of players and the Map Tile layout shown in the Mission Book.
   \item Place the Town Board of your chosen Faction in front of you and prepare the Town Building Tiles by placing them beside the Town Board.
     Check which Buildings are already built in the Scenario you are about to play, and place the respective Building Tiles on the Town Board.

--- a/sections/town.tex
+++ b/sections/town.tex
@@ -6,26 +6,26 @@
 \hypertarget{Town}{Each} Faction has their own Town, which is located in the center of their Starting Tile.
 The Town is your most important location, as many Scenarios \hyperlink{End}{may end} if it's \hyperlink{Categories}{Flagged} by an enemy Hero.\par
 The contents of your Town and overall Faction status are represented by the Town Board.
-It shows your currently built Buildings, Resource Costs for future Buildings, your Resource incomes and status of Town Action Tokens.\par
+It shows your currently built Buildings, Resource costs for future Buildings, your Resource incomes and status of Town Action Tokens.\par
 All Factions are able to Build the following Buildings in their Town:
 \begin{itemize}
   \item \textbf{City Hall} – Provides Resource income or a Faction-Specific Ability.
   \item \textbf{Citadel} – Allows you to Reinforce units when using the Population Token.
 Also \hyperlink{Walls}{protects your Town} when it is attacked.
   \item \textbf{Unit Dwellings} – Allows you to Recruit Units.
-Dwellings have three Levels that unlock new Units, but which must be Built in the following order:\includesvg[height=10px]{\svgs/bronze.svg}\includesvg[height=10px]{\svgs/silver.svg}\includesvg[height=10px]{\svgs/golden.svg}
+Dwellings have three Levels that unlock new Units, but which must be Built in the following order:\includesvg[height=10px]{\svgs/bronze.svg}\includesvg[height=10px]{\svgs/silver.svg}\includesvg[height=10px]{\svgs/Golden.svg}
   \item \textbf{Mage Guild} - gives you \hyperlink{spells}{Spells}.
   \item \textbf{Faction Building} - a Faction-Specific Building with a unique effect.
 \end{itemize}
-\textbf{A single Building} may be Built each round by using the Build Token.
+\textbf{A single Building} may be Built each Round by using the Build Token.
 When you build a Building, pay its cost in Resources, flip the Build Token to its inactive side, and place the new Building’s Cardboard Piece into its proper slot on the Town Board.
 If the Building has any immediate effects upon Building it, resolve them now.\par
 Built Buildings are always represented by a symbol within a circle.
 Buildings that can be built in the future are represented by a rectangle that contains the Building's cost in Resources.
 Many Building Tiles are double-sided, and may later be upgraded and flipped to represent two different buildings at the same time. Such upgrades must be Built in order.\par
-If a Town or Settlement is attacked by an enemy hero and your Hero is not also on that Field, you may immediately \textbf{pay 8 gold} to fight a defending Combat \textbf{using only your Units}.
+If a Town or Settlement is attacked by an enemy hero and your Hero is not also on that Field, you may immediately \textbf{pay 8 Gold} to fight a defending Combat \textbf{using only your Units}.
 You cannot use your Deck during that Combat as your Main Hero is not present.
-Paying this gold represents the cost of transporting the army there.\par
+Paying this Gold represents the cost of transporting the army there.\par
 When you \hyperlink{Categories}{Flag} a Town, take \hyperlink{End}{a Faction Cube} from its previous owner.
 
 \vspace*{\fill}

--- a/sections/units.tex
+++ b/sections/units.tex
@@ -17,8 +17,8 @@ If a unit is defeated in Combat, \textbf{discard it} from your Unit Deck.\par
 Units may be Recruited and Reinforced by flipping the Population Token and paying the Unit's Recruitment \includesvg[height=10px]{\svgs/pay.svg} or Reinforcement \includesvg[height=10px]{\svgs/reinforce.svg} cost.
 When you do so, you can instantly Recruit and Reinforce \textbf{any number} of times, provided you have enough Resources and the prerequisite Buildings to do so.\par
 
-\textbf{Recruiting} a unit requires that your Town has a Dwelling of that Unit's level (\includesvg[height=10px]{\svgs/bronze.svg}\includesvg[height=10px]{\svgs/silver.svg} \includesvg[height=10px]{\svgs/golden.svg}).
-\textbf{Reinforcing} requires that your Town has a Citadel in addition to a Dwelling of that Unit's level.
+\textbf{Recruiting} a unit requires that your Town has a Dwelling of that Unit's Level (\includesvg[height=10px]{\svgs/bronze.svg}\includesvg[height=10px]{\svgs/silver.svg} \includesvg[height=10px]{\svgs/golden.svg}).
+\textbf{Reinforcing} requires that your Town has a Citadel in addition to a Dwelling of that Unit's Level.
 If all Units in your Unit Deck are defeated, \textbf{immediately} replace your Unit Deck with the starting Units of the Scenario. Defeated Faction Units can always be re-Recruited with another use of the Population Token.\par
 
 \textbf{Important}: Any effects which allow you to Reinforce outside of using the Population Token \textbf{do not} require a Citadel or any Dwellings.
@@ -57,11 +57,11 @@ Defense may be modified by various effects such as Statistic Cards.\par
 ”Pack” units are turned back to ”Few” units, with any excess damage placed on its ”Few” side.
 After Combat, all damage is healed from all Units.
 Units retain their ”Few” or ”Pack” status between combats.\par
-\includesvg[height=30px]{\svgs/initiative.svg}{\hypertarget{Initiative}{\textbf{Initiative}}} - Determines when the Unit activates during combat.
-Units with a higher initiative activate first.
-In case of a tie, the \hyperlink{Combatterminology}{attacking} side's Unit should always activate first.
-If there are multiple ties on one side, the player who controls those Units selects which Unit to activate next.
-If there are multiple ties on both sides (for instance two attackers and two defenders with the same initiative), alternate between the attackers and defenders starting with the attacker.\par
+\includesvg[height=30px]{\svgs/initiative.svg}{\hypertarget{Initiative}{\textbf{Initiative}}} - Determines when the Unit Activates during combat.
+Units with a higher Initiative Activate first.
+In case of a tie, the \hyperlink{Combatterminology}{attacking} side's Unit should always Activate first.
+If there are multiple ties on one side, the player who controls those Units selects which Unit to Activate next.
+If there are multiple ties on both sides (for instance two attackers and two defenders with the same Initiative), alternate between the attackers and defenders starting with the attacker.\par
 \bigskip
 
 \begin{scaledfigure}[blanker]
@@ -109,15 +109,15 @@ Walls and Gates may also \hyperlink{Walls}{reduce} the damage from  \includesvg[
 Neutral Units guard the various locations on the Game Map.
 Starting and winning Combat against them is necessary to Visit most Locations.
 Neutral Units are spread into four different tiers, each with their own deck.
-In addition to \includesvg[height=10px]{\svgs/bronze.svg}, \includesvg[height=10px]{\svgs/silver.svg} and \includesvg[height=10px]{\svgs/golden.svg}, there are also Azure \includesvg[height=10px]{\svgs/azure.svg} neutral units which are the strongest in the game.\par
+In addition to \includesvg[height=10px]{\svgs/bronze.svg}, \includesvg[height=10px]{\svgs/silver.svg} and \includesvg[height=10px]{\svgs/golden.svg}, there are also Azure \includesvg[height=10px]{\svgs/azure.svg} Neutral Units which are the strongest in the game.\par
 Each of these decks should be kept separate from each other and shuffled during setup.
-If a Neutral Unit Deck ever runs out of cards, reshuffle the discard into a new deck.
-When a Combat against neutral units starts, draw \hyperlink{Difficulty}{the appropriate number} of Units from each tier to take part in that Combat.\par
+If a Neutral Unit Deck ever runs out of Cards, reshuffle the discard into a new deck.
+When a Combat against Neutral Units starts, draw \hyperlink{Difficulty}{the appropriate number} of Units from each tier to take part in that Combat.\par
 It is possible for players to gain Neutral Units to their unit deck through various effects, such as Scenario-Specific Rules or the Diplomacy Ability Card.
 \textbf{Neutral Units cannot be Reinforced}, as they are single sided.
 Whenever a Neutral Unit is defeated from anywhere, place it into the appropriate Neutral Discard Pile.\par
 In \textbf{Clash} and \textbf{Alliance} Scenarios, Neutral Units are always controlled by the next enemy player sitting to your right.
-When controlling neutral units in this way \textbf{they must always attack if possible}, or if they can't, move as close to an enemy unit as possible.\par
+When controlling Neutral Units in this way \textbf{they must always attack if possible}, or if they can't, move as close to an enemy unit as possible.\par
 
 \end{multicols}
 
@@ -132,13 +132,13 @@ When controlling neutral units in this way \textbf{they must always attack if po
 
 \begin{multicols}{2}
 
-\textit{Alamar casts a Magic Arrow against Sandro's pack of Skeletons, Empowering \includesvg[height=10px]{\svgs/empower.svg} the spell by two with the Expert  Effect \includesvg[height=10px]{\svgs/expert.svg} of a Power Card.}
+\textit{Alamar casts a Magic Arrow against Sandro's pack of Skeletons, Empowering \includesvg[height=10px]{\svgs/empower.svg} the Spell by two with the Expert  Effect \includesvg[height=10px]{\svgs/expert.svg} of a Power Card.}
 
 \includegraphics[width=\linewidth]{\examples/alamar_empowering_magic_arrow.png}
 \par
 \textit{
-  The Skeletons take 3 damage \includesvg[height=10px]{\svgs/damage.svg} from the spell.
-  Their defense \includesvg[height=10px]{\svgs/defense.svg} of 1 does not reduce the damage, because it only applies against attacks.
+  The Skeletons take 3 damage \includesvg[height=10px]{\svgs/damage.svg} from the Spell.
+  Their Defense \includesvg[height=10px]{\svgs/defense.svg} of 1 does not reduce the damage, because it only applies against attacks.
   The Skeletons have a HP \includesvg[height=10px]{\svgs/health_points.svg} of only 2, so they are now turned to their "Few" side and 1 leftover damage \includesvg[height=10px]{\svgs/damage.svg} is placed on them.
 }
 \par


### PR DESCRIPTION
Gone through more of the terms. So far, these are confirmed _game terms_ that are capitalized:

Deck, Reinforce, Settlement, Token, Field, Faction Cube, Mines, Visitable, Flaggable, Flagging, Town, Faction, Hero, Main Hero, Secondary Hero, Scenario, Alliance, Cooperative, Round, Building Material, Valuables, Gold (only the resource), Neutral Unit, Initiative, Level, Round, Spell, Visit, Revisit, Defense, Activated/Activates, Power (non-general)

These are _non-game terms_ for now:
player, hand, defeated, competitive, expansion, alternative, model, gold (general, not resource), inactive, cost, unvisited, active, inactive

A reminder that I have not decided what is a _game term_ or not, I have rather interpolated what was capitalized or not from the beginning. Feel free to have opinions on what should be a _game term_ or not.