### PR TITLE
Prune and fix sections pt1

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -229,7 +229,7 @@
   \end{tikzpicture}
 \end{titlepage}
 
-\title{\includegraphics[width=6cm]{\images/title.png}\\The Rewritening}
+\title{\includegraphics[width=6cm]{\images/title.png}\\The Rewrite}
 
 \author{Hermanni "Heegu" Karppela}
 \maketitle

--- a/sections/credits.tex
+++ b/sections/credits.tex
@@ -7,7 +7,7 @@
 
 \textbf{Author}: Heegu\par
 \textbf{GitHub engineering, LaTeX writing, graphics editing and proofreading}: qwrtln, csagataj2, jorischkovich, RickardNi\par
-\textbf{Thanks to everyone who has supported the project with suggestions, corrections, image resources and words of encouragement either on Discord or BoardGameGeek}: superdupergc, Wololoeren, life8853, imi2001, csabaidonat, k.adam, gamesjunkie, sothis86, cranky\textunderscore hobbit, hleveillegauvin, ExOblivione, hrabo, Mysticum, Cowmander, JohnnyTheGreat, Jaksonas, Stichen, Morthai, BryanKromrey, Ioan, PeterLeBagarreur, \textunderscore Count\textunderscore Dracula\textunderscore , \space Ksenon\par
+\textbf{Thanks to everyone who has supported the project with suggestions, corrections, image resources and words of encouragement either on Discord or BoardGameGeek}: superdupergc, Wololoeren, life8853, imi2001, csabaidonat, k.adam, gamesjunkie, sothis86, cranky\textunderscore hobbit, hleveillegauvin, ExOblivione, hrabo, Mysticum, Cowmander, JohnnyTheGreat, Jaksonas, Stichen, Morthai, BryanKromrey, Ioan, PeterLeBagarreur, \textunderscore Count\textunderscore Dracula\textunderscore , \space Ksenon, Netopalis, omoprof\par
 \textbf{Special thanks}: Everyone from Archon Studio, for producing the game and answering our incessant queries about rules and other topics.
 Jon Van Caneghem and everyone involved with the development of the original video game.\par
 \textbf{Artwork borrowed from official release was made by}: Tomasz Badalski, Yoann Boissonnet, Shen Fei, Viviane Tybusch Souza, Iana Vengerova, Bartosz Winkler

--- a/sections/heroes.tex
+++ b/sections/heroes.tex
@@ -10,7 +10,7 @@ Heroes are used to perform Movement Actions on the game board and to start Comba
 \subsection*{Main Hero}
 The Main Hero is represented by its chosen model and Hero Card.
 Each Faction's Main Hero has 3 Movement Points.
-Only the Main Hero can use your deck.\par
+Only the Main Hero can use your Deck.\par
 Each Main Hero starts the game at Level 1 and can advance up to Level 7 by gaining Experience.
 Experience is gained from \hyperlink{Combatexperience}{winning Combat}, Visiting certain \hyperlink{All}{Locations} and the \hyperlink{Resources}{Treasure Die} \includesvg[height=10px]{\svgs/trasuredie.svg}.
 Gaining 1 Experience is represented by the symbol \includesvg[height=10px]{\svgs/exp.svg}.
@@ -128,12 +128,14 @@ The Level Tracker on your Hero Card shows the following information:
 \item At which Levels your Main Hero must \hyperlink{Playerdecks}{\textbf{Search}} for a new \hyperlink{Ability}{Ability Card} or gain a \hyperlink{Specialty}{Specialty Card}.
 Level numbers written in gold on the Level Tracker (\includesvg[height=10px]{\svgs/level1.svg}, \includesvg[height=10px]{\svgs/level4.svg} and \includesvg[height=10px]{\svgs/level6.svg}) give you a Specialty Card, while silver Levels (2, 3, 5, 7) give you an Ability Card.
 \end{itemize}
+\vfill\null
+\columnbreak
 List of all effects:
 \begin{itemize}
 \item \textbf{Level 1} – Your Hand Limit is 4.
 Add your first Specialty Card to Your Deck.
 \item \textbf{Level 2} – Search (2) the Ability Deck.
-You may play 1 Card for their Expert Effect per Round.
+You may play 1 Card for its Expert Effect per Round.
 \item \textbf{Level 3} – Your Hand Limit is 5.
 Search (2) the Ability Deck.
 \item \textbf{Level 4} – Gain your second Specialty Card.
@@ -146,16 +148,8 @@ You may play 3 cards for their Expert Effect per Round.
 Search (2) the Ability Deck.
 \end{itemize}
 
-\subsection*{Example}
-
-\textit{Catherine the Knight begins her Turn. She starts by drawing cards from her Deck of Might \& Magic up to her Hand Limit \includesvg[height=10px]{\svgs/hand.svg} of 5, since her Main Hero is Level 3.
-She had used all of her Cards during the previous Game Round, so she does not have the opportunity to discard any Cards before drawing.}\par
-\textit{She then spends her Build Token to construct the \includesvg[height=10px]{\svgs/golden.svg} Dwelling, and then her Population Token to \hyperlink{Units}{Recruit} the \includesvg[height=10px]{\svgs/golden.svg} Unit Champions.
-She is allowed to do this, as she had previously built the prerequisite lower Level Dwellings (\includesvg[height=10px]{\svgs/bronze.svg} and \includesvg[height=10px]{\svgs/silver.svg}) and has enough \hyperlink{Resources}{Resources} to both Build the Dwelling and to Recruit the Champions.}\par
-\textit{Now prepared for a coming battle, she spends a Movement Point to move her Main Hero to an adjacent Field currently occupied by Sandro the Necromancer, an enemy Main Hero.}\par
-
-\includegraphics[width=\linewidth]{\examples/catherine_attacks_sandro.png}
-
-\textit{As Catherine declares her intent to start \hyperlink{Combat}{Combat}, Sandro still now has an opportunity to spend any of his Town, Population and/or Spell Book Tokens to also strengthen his army before Combat begins.}
-
+\vspace*{\fill}
+\begin{center}
+    \includegraphics[width=1.3\linewidth]{\art/cavalryman.png}
+\end{center}
 \end{multicols}

--- a/sections/heroes.tex
+++ b/sections/heroes.tex
@@ -12,7 +12,7 @@ The Main Hero is represented by its chosen model and Hero Card.
 Each Faction's Main Hero has 3 Movement Points.
 Only the Main Hero can use your Deck.\par
 Each Main Hero starts the game at Level 1 and can advance up to Level 7 by gaining Experience.
-Experience is gained from \hyperlink{Combatexperience}{winning Combat}, Visiting certain \hyperlink{All}{Locations} and the \hyperlink{Resources}{Treasure Die} \includesvg[height=10px]{\svgs/trasuredie.svg}.
+Experience is gained from \hyperlink{Combatexperience}{winning Combat}, Visiting certain \hyperlink{All}{Locations} and the \hyperlink{Resources}{Treasure Die} \includesvg[height=10px]{\svgs/treasure.svg}.
 Gaining 1 Experience is represented by the symbol \includesvg[height=10px]{\svgs/exp.svg}.
 
 \subsection*{\hypertarget{Secondary}{Secondary Heroes}}

--- a/sections/player_turns.tex
+++ b/sections/player_turns.tex
@@ -1,7 +1,7 @@
 % !TeX spellcheck = en_US
 \addsection{Player Turns}{\spells/dimension_door.png}
 
-\begin{multicols*}{2}
+\begin{multicols}{2}
 
 At the start of a player's Turn, that player refreshes their hand of Cards from their Deck of Might \& Magic following two steps in order:
 \begin{itemize}
@@ -37,8 +37,7 @@ Mark the amount of MP you have used by flipping your Movement Tokens over to the
 If a player has both a Main and a \hyperlink{Secondary}{Secondary Hero}, track their MP separately.
 Heroes can spend MP in any order.\par
 Allied Heroes can move through each other but cannot stop their movement in the same Field.
-When you move through a Field with an allied Hero, do not \hyperlink{Categories}{Visit} the Field that the allied Hero is standing on.
-In the unlikely situation that two allied Heroes are forced onto the same Field, you must use your next MP to move one of them away from that Field.\par
+When you move through a Field with an allied Hero, do not \hyperlink{Categories}{Visit} the Field that the allied Hero is standing on.\par
 \note{10}{
   Whenever you are instructed to gain (additional) MP, sometimes shorthanded with the symbol \includesvg[height=10px]{\svgs/movement-note.svg}, that MP persists for \textbf{only the Turn it was gained on}.
   In the unlikely situation that two allied Heroes are forced onto the same Field, you must use your next MP to move one of them away from that Field.
@@ -60,27 +59,33 @@ You cannot use that action again until the start of the next Round, when the Tok
 
 \subsection*{Morale Actions}
 Players can gain or lose Morale through various game effects.
-When you gain Morale, place a Positive Morale Token \includesvg[height=10px]{\svgs/positive.svg} near your play area.
-A player may only have one such token.
-If they would gain a second token, they may immediately spend the first one before gaining the second.
+When you gain Morale, take a Positive Morale Token \includesvg[height=10px]{\svgs/positive.svg}.
+You may only have one such Token.
+If you would gain a second Token, you may immediately spend the first one before gaining the second.
 A Positive Morale Token may be spent to perform any of the following Actions at any time:
 \begin{itemize}
   \item Draw a Card from your Deck.
   \item Discard any number of Cards, then draw that many Cards.
   \item Reroll any die you have thrown.
 \end{itemize}
-
-If a player loses Morale, they must discard a Positive Morale Token \includesvg[height=10px]{\svgs/positive.svg} without effect if they have one, otherwise they gain a Negative Morale Token \includesvg[height=10px]{\svgs/negative.svg}.
-Inversely, gaining Morale while you have a Negative Morale Token also discards it without effect.
-If a player would gain a second Negative Morale Token, they must instead discard their entire hand of Cards the next time they end their Turn.\par
+If you lose Morale, discard a Positive Morale Token \includesvg[height=10px]{\svgs/positive.svg} if you have one, otherwise gain a Negative Morale Token \includesvg[height=10px]{\svgs/negative.svg}.
+Inversely, gaining Positive Morale while you have a Negative Morale Token discards the Token.
+If you would gain a second Negative Morale Token, you must instead \textbf{discard your hand of Cards} the next time you end your Turn.\par
 
 \note{5}{The Necropolis \includesvg[height=10px]{\svgs/necro-note.svg} Faction ignores any Morale effects.
   They cannot ever gain or lose Morale for any reason.
 }
 
-\vspace*{\fill}
-\begin{center}
-  \includegraphics[width=1.3\linewidth]{\art/cavalryman.png}
-\end{center}
+\subsection*{Example Turn}
 
-\end{multicols*}
+\textit{Alice, who is playing the Hero Catherine the Knight, begins her Turn.
+She has 3 cards in her hand from the previous round, and decides to discard 2 of them before drawing cards from her Deck up to her Hand Limit \includesvg[height=10px]{\svgs/hand.svg}.
+The current limit is 5, since her Main Hero is Level 3, so she draws 4 cards after discarding (see \hyperlink{Level}{Level Effects}).}\par
+\textit{She then spends her Build Token to construct the \includesvg[height=10px]{\svgs/golden.svg} Dwelling, and then her Population Token to \hyperlink{Units}{Recruit} the \includesvg[height=10px]{\svgs/golden.svg} Unit Champions.
+She is allowed to do this, as she had previously built the prerequisite lower Level Dwellings (\includesvg[height=10px]{\svgs/bronze.svg} and \includesvg[height=10px]{\svgs/silver.svg}) and has enough \hyperlink{Resources}{Resources} to both Build the Dwelling and to Recruit the Champions.}\par
+\textit{Now prepared for a coming battle, she spends a Movement Point to move her Main Hero to an adjacent Field currently occupied by Sandro the Necromancer, an enemy Main Hero controlled by Bob.
+As Melissa announces her intent to start Combat, both players still now have an opportunity to perform Town Actions.}\par
+
+\includegraphics[width=\linewidth]{\examples/catherine_attacks_sandro.png}
+
+\end{multicols}

--- a/sections/round_structure.tex
+++ b/sections/round_structure.tex
@@ -20,14 +20,9 @@ Then, depending on the current Round number, players either gain Resources or re
     Draw an Astrologers Proclaim Card and resolve its effects.
   \item If the Scenario has timed Events marked on the Round Tracker that have now been reached, resolve them.
 \end{itemize}
-\subsection*{Player Actions}
-\begin{itemize}
-  \item During their turn, players spend their Movement Points (MP) to perform Actions with their Heroes.
-  \item Build, Population and Spell Book Tokens may be used at any point during any player's Turn except during Combat.
-  \item Once all players have performed their Turn, move the Black Cube on the Round Tracker and perform the start of Round again.
-\end{itemize}
+After the start of the Round, players take turns in a clockwise order as described in the next section.
+After all players have played their turn, move the Black Cube on the Round Tracker one space forward and perform the start of Round again.
 Keep playing new Rounds until any of the Scenario's ending conditions have been met.
-
 \vfill
 \hspace{2em}
 \includegraphics[width=1.3\linewidth]{\art/minotaur.png}


### PR DESCRIPTION
Part 1 of going through Chiss's latest remarks. This prunes page 8's ending and moves the "Catherine attacks Sandro" example to page 10. Also some tiny changes here and there such as Capitalizations.