### PR TITLE
Remove shorthanded

### DIFF
--- a/sections/credits.tex
+++ b/sections/credits.tex
@@ -7,7 +7,7 @@
 
 \textbf{Author}: Heegu\par
 \textbf{GitHub engineering, LaTeX writing, graphics editing and proofreading}: qwrtln, csagataj2, jorischkovich, RickardNi\par
-\textbf{Thanks to everyone who has supported the project with suggestions, corrections, image resources and words of encouragement either on Discord or BoardGameGeek}: superdupergc, Wololoeren, life8853, imi2001, csabaidonat, k.adam, gamesjunkie, sothis86, cranky\textunderscore hobbit, hleveillegauvin, ExOblivione, hrabo, Mysticum, Cowmander, JohnnyTheGreat, Jaksonas, Stichen, Morthai, BryanKromrey, Ioan, PeterLeBagarreur, \textunderscore Count\textunderscore Dracula\textunderscore , \space Ksenon, Netopalis, omoprof, AkenoSenpai, Zerbique\par
+\textbf{Thanks to everyone who has supported the project with suggestions, corrections, image resources and words of encouragement either on Discord or BoardGameGeek}: superdupergc, Wololoeren, life8853, imi2001, csabaidonat, k.adam, gamesjunkie, sothis86, cranky\textunderscore hobbit, hleveillegauvin, ExOblivione, hrabo, Mysticum, Cowmander, JohnnyTheGreat, Jaksonas, Stichen, Morthai, BryanKromrey, Ioan, PeterLeBagarreur, \textunderscore Count\textunderscore Dracula\textunderscore , \space Ksenon, Netopalis, omoprof, AkenoSenpai, Zerbique, Cantila\par
 \textbf{Special thanks}: Everyone from Archon Studio, for producing the game and answering our incessant queries about rules and other topics.
 Jon Van Caneghem and everyone involved with the development of the original video game.\par
 \textbf{Artwork borrowed from official release was made by}: Tomasz Badalski, Yoann Boissonnet, Shen Fei, Viviane Tybusch Souza, Iana Vengerova, Bartosz Winkler

--- a/sections/player_turns.tex
+++ b/sections/player_turns.tex
@@ -39,7 +39,7 @@ Heroes can spend MP in any order.\par
 Allied Heroes can move through each other but cannot stop their movement in the same Field.
 When you move through a Field with an allied Hero, do not \hyperlink{Categories}{Visit} the Field that the allied Hero is standing on.\par
 \note{10}{
-  Whenever you are instructed to gain (additional) MP, sometimes shorthanded with the symbol \includesvg[height=10px]{\svgs/movement-note.svg}, that MP persists for \textbf{only the Turn it was gained on}.
+  Whenever you are instructed to gain (additional) MP, sometimes represented by the symbol \includesvg[height=10px]{\svgs/movement-note.svg}, that MP persists for \textbf{only the Turn it was gained on}.
   In the unlikely situation that two allied Heroes are forced onto the same Field, you must use your next MP to move one of them away from that Field.
 }
 

--- a/sections/setup.tex
+++ b/sections/setup.tex
@@ -43,7 +43,7 @@ This section will guide you through the process of setting up a Scenario from th
   \item If your Main Hero is a Hero of Might \includesvg[height=10px]{\svgs/might.svg}, add 1 copy of the Magic Arrow Spell to your Deck, and if they’re a Hero of Magic \includesvg[height=10px]{\svgs/magic.svg}, add 2 of these Spells to your Deck.
   \item Add your Hero's \hyperlink{Ability}{Ability} and Level 1 \hyperlink{Specialty}{Specialty} Cards to your Starting Deck.
   \item Shuffle your Starting Deck and place it face down next to your Hero Card.
-    This Deck is your Main Hero's \textbf{Deck of Might \& Magic}, and is now ready for play. From this point in this rule book, this deck will be \textbf{shorthanded} to \textbf{Your Deck}.
+    This Deck is your Main Hero's \textbf{Deck of Might \& Magic}, and is now ready for play. In this rule book, this is shortened to \textbf{Your Deck}.
   \item Sort the Ability, Artifact, and Spell Cards into 3 face down Decks (including any unused Magic Arrow Spells) and shuffle them.
     From each of these Decks, take the top Card and place it face up next to its Deck, creating 3 separate Discard Piles.
   \item Choose the Scenario's \hyperlink{Difficulty}{Difficulty} and take the corresponding Starting Bonus(es).


### PR DESCRIPTION
Removes the expression "shorthanded" from the two places it was used at. It wasn't very idiomatic. "Shorthand for something" is, but using it felt awkward. Change suggested by discord user Cantila whom I added to the credits.