### PR TITLE
Various edits from the roadmap.

### DIFF
--- a/assets/glyphs/damage-note.svg
+++ b/assets/glyphs/damage-note.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="-118 0 1697 1000"
+   id="svg1"
+   sodipodi:docname="damage-note.svg"
+   inkscape:export-filename="../../../../damage-note.svg"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="0.50500884"
+     inkscape:cx="638.60268"
+     inkscape:cy="764.34306"
+     inkscape:window-width="1440"
+     inkscape:window-height="868"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <path
+     fill="currentColor"
+     d="M1203 -99q17 35 41.5 86.5t76 168.5t91 217.5t71 207t31.5 162.5q0 104 -42 192t-114 139t-157.5 51t-157.5 -51t-114 -139t-42 -192q0 -67 39.5 -193.5t101 -269.5t98.5 -225t68 -146q-41 42 -178.5 187t-283.5 296t-251 255q-64 63 -131 132q13 19 30 37q27 28 62 48 q0 -12 6 -22q11 -20 35 -24q28 -4 50 20q13 15 15 37t-8 38q-14 27 -58 34q-31 6 -70 -9q-36 -14 -77 -47q-34 -27 -62 -58q-6 6 -18 19q-9 10 -21 21q-20 21 -49 48q-58 54 -124 106q4 40 -25 68q-25 25 -60 25.5t-60 -24.5q-24 -25 -24 -60t25 -60q29 -28 68 -25 q51 -64 106 -124q27 -29 48 -49l21 -21q6 -6 19 -18q-31 -29 -58 -62q-33 -41 -47 -77q-15 -38 -9 -69q8 -43 34 -59q17 -9 38.5 -7.5t37.5 15.5q24 22 19 49q-3 24 -24 36q-9 5 -22 5q20 35 48 62q17 16 38 30q58 -57 132 -131q150 -151 449 -436.5t326 -312.5 q35 -36 77 -58q46 -25 102 -34l1 -1v1h2v1h1l-2 1q-8 56 -33 103q-22 42 -58 77q-10 10 -28 29z"
+     id="path1"
+     style="fill:#e8d66b;fill-opacity:1" />
+</svg>

--- a/sections/all_map_locations.tex
+++ b/sections/all_map_locations.tex
@@ -3,18 +3,19 @@
 
 \begin{multicols*}{2}
 
-\hypertarget{All}{This} section describes the function of every single Field in the game.
-Any Fields not shown below or in the above Expansion section are explained by the reference sheet found at the back of the official rule book, pictured on the right. All such fields are \textbf{Visitable}.\par
+\hypertarget{All}{This} section describes the function of Fields not explained above.
+The following \textbf{Visitable} fields are not pictured out of redundancy, as their effects are described clearly by the symbols at the back of the official rule book (pictured on the right): \textbf{Water Wheel}, \textbf{Windmill}, \textbf{Mystical Garden}, \textbf{Shrine of Magic Gesture/Incantation}, \textbf{Learning Stone}, \textbf{Temple}, \textbf{Warrior's Tomb}, \textbf{Fountain of Youth}, \textbf{Treasure Symbol}, \textbf{Artifact Symbol}, \textbf{Resource Symbol}, \textbf{Pandora's Box}.\par
 \bigbreak
-\note{10}{
+\note{8}{
     The effects of Fields that allow you to \textbf{Search} for Spells or Artifacts, or where you must spend resources to use the Field's effect, are \textbf{always optional}.
     You must always place a Black Cube on such Visitable Fields even if you choose not to use that Field's effect.
 }
 
 \vfill
+
 \begin{center}
-  \hspace{-10em}
-  \includegraphics[width=\linewidth]{\art/ballista.png}
+    \hspace{-14em}
+    \includegraphics[width=0.8\linewidth]{\art/ballista.png}
 \end{center}
 
 \begin{center}
@@ -54,7 +55,7 @@ All mines have the \includesvg[height=10px]{\svgs/ongoing.svg} symbol and a pict
 When you Flag a Settlement, choose whether to increase your \includesvg[height=10px]{\svgs/gold.svg}, \includesvg[height=10px]{\svgs/building_materials.svg} or \includesvg[height=10px]{\svgs/valuablegreater.svg} income by one space.
 As with Mines, if you are the first player to Flag a Settlement, you immediately gain Resources equal to that increase in production.
 Mark the Settlement with an appropriate Resource Token to show which Resource it produces.
-When you Flag an enemy Settlement you may switch that Resource.\par
+When you Flag an enemy Settlement, you may change which Resource it produces.\par
 Additionally, \textbf{instead of increasing Resource Production}, you may choose to \textbf{Reinforce} one of your \includesvg[height=10px]{\svgs/bronze.svg} or \includesvg[height=10px]{\svgs/silver.svg} Units immediately for half the normal cost, rounded up.
 If you were the first player to Flag the Settlement, Reinforce that Unit \textbf{for free} instead.
 Do not place any Resource Tokens on the Settlement if you choose to Reinforce.

--- a/sections/all_map_locations.tex
+++ b/sections/all_map_locations.tex
@@ -4,19 +4,27 @@
 \begin{multicols*}{2}
 
 \hypertarget{All}{This} section describes the function of Fields not explained above.
-The following \textbf{Visitable} fields are not pictured out of redundancy, as their effects are described clearly by the symbols at the back of the official rule book (pictured on the right): \textbf{Water Wheel}, \textbf{Windmill}, \textbf{Mystical Garden}, \textbf{Shrine of Magic Gesture/Incantation}, \textbf{Learning Stone}, \textbf{Temple}, \textbf{Warrior's Tomb}, \textbf{Fountain of Youth}, \textbf{Treasure Symbol}, \textbf{Artifact Symbol}, \textbf{Resource Symbol}, \textbf{Pandora's Box}.\par
+The following \textbf{Visitable} fields are not pictured out of redundancy, as their effects are described clearly by the symbols on the right:
+\begin{itemize}
+    \item Artifact Symbol
+    \item Fountain of Youth
+    \item Learning Stone
+    \item Mystical Garden
+    \item Pandora's Box
+    \item Resource Symbol
+    \item Shrine of Magic Gesture/Incantation
+    \item Temple
+    \item Treasure Symbol
+    \item Warrior's Tomb
+    \item Water Wheel
+    \item Windmill
+\end{itemize}
+
 \bigbreak
-\note{8}{
+\note{10}{
     The effects of Fields that allow you to \textbf{Search} for Spells or Artifacts, or where you must spend resources to use the Field's effect, are \textbf{always optional}.
     You must always place a Black Cube on such Visitable Fields even if you choose not to use that Field's effect.
 }
-
-\vfill
-
-\begin{center}
-    \hspace{-14em}
-    \includegraphics[width=0.8\linewidth]{\art/ballista.png}
-\end{center}
 
 \begin{center}
   \framedimage[\linewidth]{\tables/symbols.png}

--- a/sections/combat.tex
+++ b/sections/combat.tex
@@ -50,14 +50,14 @@ Unit setup when fighting \textbf{other players}:
 }
 
 \subsection*{\hypertarget{Combatterminology}{Combat Terminology}}
-The following terms are used in this rule book and by the Unit and other cards to describe effects and elements during Combat:\par
-\textbf{Attacking Playe}r – The player who started the Combat by moving their Hero.\par
+The following terms are used to describe effects and elements during Combat:\par
+\textbf{Attacking Playe}r – The player who started the Combat.\par
 \textbf{Defending Player} – The player whom Combat was started against.\par
 \textbf{Activation} – A Unit Activates when it is next in the Initiative order.\par
 \textbf{Adjacent Unit} – A Unit is directly adjacent to another if it is one space away in a cardinal direction (nondiagonal).\par
 \textbf{Combat Round} – A full cycle of all Units of each player being Activated.\par
-\textbf{Combat Obstacles}\index{Combat Obstacles}\index{Obstacles, Combat} – Every card placed on the Combat Board counts as a Combat Obstacle.
-Obstacles block the movement of all non-flying Units.\par
+\textbf{Combat Obstacles}\index{Combat Obstacles}\index{Obstacles, Combat} – Every card on the Combat Board is a Combat Obstacle.
+They block the movement of all non-flying Units.\par
 \textbf{Attack Die}\index{Attack Die} – A red Die whose results range from -1 to +1.
 Roll the Die \textbf{whenever a Unit attacks} and
 add the result to the Unit's Attack value.\par
@@ -65,9 +65,9 @@ add the result to the Unit's Attack value.\par
 Each Unit can perform \textbf{only 1} Retaliation Attack\index{Retaliation Attack} per Combat Round.
 Retaliation Attacks function identically to normal attacks, but they cannot cause another Retaliation Attack.
 Mark Units which have performed a Retaliation Attack this Round with a black cube.\par
-\textbf{Paralysis}\index{Paralysis} \includesvg[height=10px]{\svgs/paralysis.svg} – Effects which paralyze a Unit place the Paralysis Token on them.
-A paralyzed Unit \textbf{skips its next Activation} and removes the token instead.
-If it is \textbf{attacked or takes any damage} before that time, \textbf{remove the Paralysis Token} from that Unit.\par
+\textbf{Paralysis}\index{Paralysis} \includesvg[height=10px]{\svgs/paralysis.svg} – Some effects can place a Paralysis Token on a Unit.
+That Unit \textbf{skips its next Activation} and removes the Token instead.
+If it is \textbf{attacked or takes any damage} before that time, \textbf{remove the Token}.\par
 \textbf{\hypertarget{Defend}{Defend}} \includesvg[height=10px]{\svgs/defense.svg} – Units may choose to gain a Defense Token instead of attacking.
 When a Unit with a Defense Token is attacked, make another roll with the attack Die after the initial attack roll.
 If you roll a "+1", the defending Unit gains an extra 1 Defense for this attack.
@@ -78,12 +78,12 @@ The Unit cannot take another Defense Action during that activation.
 You may only use \textbf{one Spell per Combat Round}.
 Other card types can be used as many times as you want to.
 Ongoing \includesvg[height=10px]{\svgs/ongoing.svg} and \includesvg[height=10px]{\svgs/activation.svg} Activate effects can be used only \textbf{when Activating one of your Units and before it attacks}.
-Ongoing effects\index{Ongoing Effects} last until end of Combat or if the effect on the card is used up.
+Ongoing effects\index{Ongoing Effects} last until end of Combat or if the effect on the card is used up.\par
 Instant \includesvg[height=10px]{\svgs/instant.svg} Cards may be played \textbf{at any time} except between rolling the Combat Die and resolving damage unless otherwise stated.
-Instant Cards\index{Instant Card} which increase a Unit's Statistics \textbf{last only for the duration of the currently Activated Unit's next attack}.
+Cards which increase a Unit's \includesvg[height=10px]{\svgs/attack.svg} or \includesvg[height=10px]{\svgs/defense.svg}, such as the Attack and Defense Statistic cards, \textbf{must} be played after an attack has been announced and persist only for the duration of that attack.
 \subsection*{\hypertarget{Timelimit}{Combat Time Limits}}\index{Time Limit}
 Combats against Neutral Units have a time limit of \textbf{one Combat Round}.
-If you cannot win the Combat before the end of the current Combat Round, you must either \hyperlink{Endcombat}{Retreat}\index{Retreat} or spend 1 MP from the Hero that started the Combat in order to play another Combat Round.\par
+If you cannot win the Combat before the end of the current Combat Round, you must either \hyperlink{Endcombat}{Retreat}\index{Retreat} or spend 1 MP from the Hero that started the Combat in order to play another Round.\par
 
 \bigskip
 
@@ -186,33 +186,38 @@ Winning Combat with your Main Hero usually grants them Experience\index{Experien
 If either the Difficulty of the Neutral Field or the Level of a defeated enemy Main Hero was equal to your Level, gain 1 \includesvg[height=10px]{\svgs/exp.svg}.
 If they were higher than your Level, gain 2 \includesvg[height=10px]{\svgs/exp.svg}.
 Winning a Neutral Combat against a Neutral Azure \includesvg[height=10px]{\svgs/azure.svg} Unit grants your Hero Level 7 immediately.
-If you ever gain multiple Levels at the same time, resolve their effects in order.\par
+If you ever gain multiple Levels at the same time, resolve their effects in order.
+Level ups must be resolved before Visiting the Field where the Combat happened.\par
 Secondary Heroes cannot ever gain Experience.
-You also \textbf{do not gain} Experience from defeating a Secondary Hero, or if an enemy Hero Surrenders to you.
+You also \textbf{do not gain} Experience from defeating a Secondary Hero, or if an enemy Hero Surrenders to you.\par
+
 \subsection*{\hypertarget{Quick}{Quick Combat}}\index{Quick Combat}
 If your Hero's Level is higher than a Field's Difficulty when Combat against Neutral Units would begin, \textbf{no Combat} takes place.
 The player is considered to have beaten the Neutral Units by default and gains no rewards from the Combat.
 
 \subsection*{\hypertarget{AIrules}{Player vs AI}}
 These rules apply when playing a \textbf{Solo} game.\index{Solo Mode}
-The AI Combat rules for targeting and attacking are also used when playing a \textbf{Cooperative} Scenario.\par
-Solo Campaigns are played against AI Heroes who use two automated Decks to play the game: the AI Deck, and the Spell Deck.
+The AI Combat rules for unit behaviour are also used when playing a \textbf{Cooperative} Scenario.\par
+Solo Campaigns are played against AI Heroes who use two automated Decks to play the game: the \textbf{AI Deck}, and the \textbf{Spell Deck}.
+Each Campaign Scenario contains instructions for constructing these Decks.\par
 The AI Deck consists of cards that are similar in function to Abilities and Artifacts, but change depending on the game's \hyperlink{Difficulty}{Difficulty}.
+When an \textbf{AI hero} Activates a Unit, draw an AI Card\index{AI Card} and follow its instructions before the Unit moves and/or attacks.
 The Spell Deck should be used when instructed by the cards in the AI Deck.
-During Combat against Neutral enemies or AI Heroes, their Units follow an automatic set of instructions.
+If an AI Hero is instructed to draw a card, they will draw and resolve another card from the AI Deck.\par
+During Combat against Neutral enemies or AI Heroes, their Units follow an automatic set of instructions:
+\par
 \textbf{Initiative rules} work identically.
-When an \textbf{AI hero} Activates a Unit, draw an AI Card\index{AI Card} and follow its instructions as the Unit's Activation.\par
-All AI controlled \includesvg[height=10px]{\svgs/unit_ground.svg} and \includesvg[height=10px]{\svgs/unit_flying.svg} Units prioritize attacking Units of the same tier.
+\includesvg[height=10px]{\svgs/unit_ground.svg} and \includesvg[height=10px]{\svgs/unit_flying.svg} Units prioritize attacking Units of the same tier.
 If this is impossible, they attack the closest Unit, prioritizing the lowest tier one.
 \includesvg[height=10px]{\svgs/unit_ranged.svg} Units prioritize attacking other \includesvg[height=10px]{\svgs/unit_ranged.svg} Units of the same tier, then lower tier, and finally higher tier.
 If there are no \includesvg[height=10px]{\svgs/unit_ranged.svg} Units for them to target they prioritize \includesvg[height=10px]{\svgs/unit_ground.svg} and \includesvg[height=10px]{\svgs/unit_flying.svg} Units in the same tier order.
 If there's more than one valid target, they attack the closest one.\par
-If there's ever a tie between equally valid targets for any Units, the players choose which Unit is attacked.
+If there's ever a tie between equally valid targets for any Units, the players choose which Unit is attacked. Enemy units cannot \hyperlink{Defend}{Defend} unless instructed to.
 
 \textbf{AI Heroes} always start in their Town's Field unless otherwise stated.
 They have 3 MP and always use them to perform the following Actions in decreasing priority:
 \begin{itemize}
-  \item Check if a player Hero is on the same Tile as the AI.
+  \item Check if a player's Hero is on the same Tile as the AI.
     If they are, spend all MP to move towards them in an attempt to begin Combat.
   \item Check if there are any Mines or Settlements to Flag on the Map Tile the AI Hero is on.
     If there are any, move toward the closest one and Flag it.

--- a/sections/combat.tex
+++ b/sections/combat.tex
@@ -51,7 +51,7 @@ Unit setup when fighting \textbf{other players}:
 
 \subsection*{\hypertarget{Combatterminology}{Combat Terminology}}
 The following terms are used to describe effects and elements during Combat:\par
-\textbf{Attacking Playe}r – The player who started the Combat.\par
+\textbf{Attacking Player} – The player who started the Combat.\par
 \textbf{Defending Player} – The player whom Combat was started against.\par
 \textbf{Activation} – A Unit Activates when it is next in the Initiative order.\par
 \textbf{Adjacent Unit} – A Unit is directly adjacent to another if it is one space away in a cardinal direction (nondiagonal).\par
@@ -80,7 +80,7 @@ Other card types can be used as many times as you want to.
 Ongoing \includesvg[height=10px]{\svgs/ongoing.svg} and \includesvg[height=10px]{\svgs/activation.svg} Activate effects can be used only \textbf{when Activating one of your Units and before it attacks}.
 Ongoing effects\index{Ongoing Effects} last until end of Combat or if the effect on the card is used up.\par
 Instant \includesvg[height=10px]{\svgs/instant.svg} Cards may be played \textbf{at any time} except between rolling the Combat Die and resolving damage unless otherwise stated.
-Cards which increase a Unit's \includesvg[height=10px]{\svgs/attack.svg} or \includesvg[height=10px]{\svgs/defense.svg}, such as the Attack and Defense Statistic cards, \textbf{must} be played after an attack has been announced and persist only for the duration of that attack.
+Instant Cards which increase a Unit's \includesvg[height=10px]{\svgs/attack.svg} or \includesvg[height=10px]{\svgs/defense.svg}, such as the Attack and Defense Statistic cards, \textbf{must} be played after an attack has been announced and persist only for the duration of that attack.
 \subsection*{\hypertarget{Timelimit}{Combat Time Limits}}\index{Time Limit}
 Combats against Neutral Units have a time limit of \textbf{one Combat Round}.
 If you cannot win the Combat before the end of the current Combat Round, you must either \hyperlink{Endcombat}{Retreat}\index{Retreat} or spend 1 MP from the Hero that started the Combat in order to play another Round.\par
@@ -183,13 +183,13 @@ After winning Combat, Heroes \textbf{must} Visit the Field where the Combat took
 \subsection*{\hypertarget{Combatexperience}{Combat Experience}}
 
 Winning Combat with your Main Hero usually grants them Experience\index{Experience}.
-If either the Difficulty of the Neutral Field or the Level of a defeated enemy Main Hero was equal to your Level, gain 1 \includesvg[height=10px]{\svgs/exp.svg}.
-If they were higher than your Level, gain 2 \includesvg[height=10px]{\svgs/exp.svg}.
-Winning a Neutral Combat against a Neutral Azure \includesvg[height=10px]{\svgs/azure.svg} Unit grants your Hero Level 7 immediately.
+If either the Difficulty of the Neutral Field or the Level of a defeated enemy Main Hero was \textbf{equal} to your Level, gain 1 \includesvg[height=10px]{\svgs/exp.svg}.
+If they were \textbf{higher} than your Level, gain 2 \includesvg[height=10px]{\svgs/exp.svg}.
+Winning a Neutral Combat against a Neutral Azure \includesvg[height=10px]{\svgs/azure.svg} Unit grants your Hero Level 7 \textbf{immediately}.
 If you ever gain multiple Levels at the same time, resolve their effects in order.
 Level ups must be resolved before Visiting the Field where the Combat happened.\par
 Secondary Heroes cannot ever gain Experience.
-You also \textbf{do not gain} Experience from defeating a Secondary Hero, or if an enemy Hero Surrenders to you.\par
+You also do not gain Experience from \textbf{defeating} a Secondary Hero, or if an enemy Hero \textbf{Surrenders} to you.
 
 \subsection*{\hypertarget{Quick}{Quick Combat}}\index{Quick Combat}
 If your Hero's Level is higher than a Field's Difficulty when Combat against Neutral Units would begin, \textbf{no Combat} takes place.
@@ -212,7 +212,8 @@ If this is impossible, they attack the closest Unit, prioritizing the lowest tie
 \includesvg[height=10px]{\svgs/unit_ranged.svg} Units prioritize attacking other \includesvg[height=10px]{\svgs/unit_ranged.svg} Units of the same tier, then lower tier, and finally higher tier.
 If there are no \includesvg[height=10px]{\svgs/unit_ranged.svg} Units for them to target they prioritize \includesvg[height=10px]{\svgs/unit_ground.svg} and \includesvg[height=10px]{\svgs/unit_flying.svg} Units in the same tier order.
 If there's more than one valid target, they attack the closest one.\par
-If there's ever a tie between equally valid targets for any Units, the players choose which Unit is attacked. Enemy units cannot \hyperlink{Defend}{Defend} unless instructed to.
+If there's ever a tie between equally valid targets for any Units, the player chooses which Unit is attacked.
+Enemy units cannot \hyperlink{Defend}{Defend} unless instructed to.
 
 \textbf{AI Heroes} always start in their Town's Field unless otherwise stated.
 They have 3 MP and always use them to perform the following Actions in decreasing priority:

--- a/sections/credits.tex
+++ b/sections/credits.tex
@@ -7,7 +7,7 @@
 
 \textbf{Author}: Heegu\par
 \textbf{GitHub engineering, LaTeX writing, graphics editing and proofreading}: qwrtln, csagataj2, jorischkovich, RickardNi, Cyber\par
-\textbf{Thanks to everyone who has supported the project with suggestions, corrections, image resources and words of encouragement either on Discord or BoardGameGeek}: superdupergc, Wololoeren, life8853, imi2001, csabaidonat, k.adam, gamesjunkie, sothis86, cranky\textunderscore hobbit, hleveillegauvin, ExOblivione, hrabo, Mysticum, Cowmander, JohnnyTheGreat, Jaksonas, Stichen, Morthai, BryanKromrey, Ioan, PeterLeBagarreur, \textunderscore Count\textunderscore Dracula\textunderscore , \space Ksenon, Netopalis, omoprof, AkenoSenpai, Zerbique, Cantila, TheTinkler\par
+\textbf{Thanks to everyone who has supported the project with suggestions, corrections, image resources and words of encouragement either on Discord or BoardGameGeek}: superdupergc, Wololoeren, life8853, imi2001, csabaidonat, k.adam, gamesjunkie, sothis86, cranky\textunderscore hobbit, hleveillegauvin, ExOblivione, hrabo, Mysticum, Cowmander, JohnnyTheGreat, Jaksonas, Stichen, Morthai, BryanKromrey, Ioan, PeterLeBagarreur, \textunderscore Count\textunderscore Dracula\textunderscore , \space Ksenon, Netopalis, omoprof, AkenoSenpai, Zerbique, Cantila, TheTinkler, fmestevez\par
 \textbf{Special thanks}: Everyone from Archon Studio, for producing the game and answering our incessant queries about rules and other topics.
 Jon Van Caneghem and everyone involved with the development of the original video game.\par
 \textbf{Artwork borrowed from official release was made by}: Tomasz Badalski, Yoann Boissonnet, Shen Fei, Viviane Tybusch Souza, Iana Vengerova, Bartosz Winkler

--- a/sections/credits.tex
+++ b/sections/credits.tex
@@ -7,7 +7,7 @@
 
 \textbf{Author}: Heegu\par
 \textbf{GitHub engineering, LaTeX writing, graphics editing and proofreading}: qwrtln, csagataj2, jorischkovich, RickardNi, Cyber\par
-\textbf{Thanks to everyone who has supported the project with suggestions, corrections, image resources and words of encouragement either on Discord or BoardGameGeek}: superdupergc, Wololoeren, life8853, imi2001, csabaidonat, k.adam, gamesjunkie, sothis86, cranky\textunderscore hobbit, hleveillegauvin, ExOblivione, hrabo, Mysticum, Cowmander, JohnnyTheGreat, Jaksonas, Stichen, Morthai, BryanKromrey, Ioan, PeterLeBagarreur, \textunderscore Count\textunderscore Dracula\textunderscore , \space Ksenon, Netopalis, omoprof, AkenoSenpai, Zerbique, Cantila\par
+\textbf{Thanks to everyone who has supported the project with suggestions, corrections, image resources and words of encouragement either on Discord or BoardGameGeek}: superdupergc, Wololoeren, life8853, imi2001, csabaidonat, k.adam, gamesjunkie, sothis86, cranky\textunderscore hobbit, hleveillegauvin, ExOblivione, hrabo, Mysticum, Cowmander, JohnnyTheGreat, Jaksonas, Stichen, Morthai, BryanKromrey, Ioan, PeterLeBagarreur, \textunderscore Count\textunderscore Dracula\textunderscore , \space Ksenon, Netopalis, omoprof, AkenoSenpai, Zerbique, Cantila, TheTinkler\par
 \textbf{Special thanks}: Everyone from Archon Studio, for producing the game and answering our incessant queries about rules and other topics.
 Jon Van Caneghem and everyone involved with the development of the original video game.\par
 \textbf{Artwork borrowed from official release was made by}: Tomasz Badalski, Yoann Boissonnet, Shen Fei, Viviane Tybusch Souza, Iana Vengerova, Bartosz Winkler

--- a/sections/deckbuilding.tex
+++ b/sections/deckbuilding.tex
@@ -34,7 +34,7 @@ Each player's Deck starts with 9 cards, built during the game's setup.
 
 \vfill
 \begin{center}
-    \includegraphics[width=0.7\linewidth]{\art/gremlin.png}
+  \includegraphics[width=0.7\linewidth]{\art/gremlin.png}
 \end{center}
 
 \clearpage

--- a/sections/deckbuilding.tex
+++ b/sections/deckbuilding.tex
@@ -33,9 +33,8 @@ Each player's Deck starts with 9 cards, built during the game's setup.
 }
 
 \vfill
-\begin{center}
-  \includegraphics[width=0.7\linewidth]{\art/gremlin.png}
-\end{center}
+\raggedleft
+\includegraphics[width=0.7\linewidth]{\art/gremlin.png}
 
 \clearpage
 

--- a/sections/deckbuilding.tex
+++ b/sections/deckbuilding.tex
@@ -26,7 +26,7 @@ Each player's Deck starts with 9 cards, built during the game's setup.
     \item \textbf{Map} \includesvg[height=10px]{\svgs/map.svg} Effects cannot be used during Combat.
     \item \textbf{Ongoing} \includesvg[height=10px]{\svgs/ongoing.svg} Effects last until they are used up or until the player who played them starts their next Turn (whichever happens first).
     \item \textbf{Permanent} \includesvg[height=10px]{\svgs/permanent.svg} Cards\index{Permanent Cards} stay in play until discarded or replaced.
-    \textbf{You may have only one permanent Card at a time}; playing another discards the first.
+      \textbf{You may have only one permanent Card at a time}; playing another discards the first.
   \end{itemize}
 \end{enumerate}
 \note{7}{Most Cards can only be played during or outside of Combat, as indicated by the above symbols or the Card's text. Instant \includesvg[height=10px]{\svgs/instant-note.svg} Cards which modify a \hyperlink{Units}{Unit's} statistics or deal damage \includesvg[height=10px]{\svgs/damage-note.svg} cannot be used outside of Combat.

--- a/sections/deckbuilding.tex
+++ b/sections/deckbuilding.tex
@@ -21,18 +21,20 @@ Each player's Deck starts with 9 cards, built during the game's setup.
     Also, whenever one of these Discard Piles is empty, \textbf{refill it} with that Deck's top Card.
   \item Cards in Your Deck have the following types of effects:
   \begin{itemize}
-    \item \textbf{Instant} \includesvg[height=10px]{\svgs/instant.svg} Effects are resolved immediately and can be played \textbf{out of Turn during Combat}.
+    \item \textbf{Instant} \includesvg[height=10px]{\svgs/instant.svg} Effects are resolved immediately.
     \item \textbf{Activation} \includesvg[height=10px]{\svgs/activation.svg} Effects must be played when Activating your own Unit in Combat.
     \item \textbf{Map} \includesvg[height=10px]{\svgs/map.svg} Effects cannot be used during Combat.
     \item \textbf{Ongoing} \includesvg[height=10px]{\svgs/ongoing.svg} Effects last until they are used up or until the player who played them starts their next Turn (whichever happens first).
-    \item \textbf{Permanent} \includesvg[height=10px]{\svgs/permanent.svg} Cards\index{Permanent Cards} stay in your play area until discarded or replaced.
-      \textbf{Players may have only one permanent Card at a time}; playing another discards the first.
+    \item \textbf{Permanent} \includesvg[height=10px]{\svgs/permanent.svg} Cards\index{Permanent Cards} stay in play until discarded or replaced.
+    \textbf{You may have only one permanent Card at a time}; playing another discards the first.
   \end{itemize}
 \end{enumerate}
+\note{7}{Most Cards can only be played during or outside of Combat, as indicated by the above symbols or the Card's text. Instant \includesvg[height=10px]{\svgs/instant-note.svg} Cards which modify a \hyperlink{Units}{Unit's} statistics or deal damage \includesvg[height=10px]{\svgs/damage-note.svg} cannot be used outside of Combat.
+}
 
-\vspace*{\fill}
+\vfill
 \begin{center}
-  \includegraphics[width=\linewidth]{\art/gremlin.png}
+    \includegraphics[width=0.7\linewidth]{\art/gremlin.png}
 \end{center}
 
 \clearpage

--- a/sections/heroes.tex
+++ b/sections/heroes.tex
@@ -125,7 +125,7 @@ The Level Tracker on your Hero Card shows the following information:
 \item Your Main Hero's current Level and amount of Experience gained, shown by the cube's position.
 \item Your current Hand Limit \includesvg[height=10px]{\svgs/hand.svg}.
 \item The number of \hyperlink{Ability}{Expert Effects} \includesvg[height=10px]{\svgs/expert.svg} you may use during a Round.
-\item At which Levels your Main Hero must \hyperlink{Playerdecks}{\textbf{Search}} for a new \hyperlink{Ability}{Ability Card} or gain a \hyperlink{Specialty}{Specialty Card}.
+\item At which Levels your Main Hero must \hyperlink{Playerdecks}{Search} for a new \hyperlink{Ability}{Ability Card} or gain a \hyperlink{Specialty}{Specialty Card}.
 Level numbers written in gold on the Level Tracker (\includesvg[height=10px]{\svgs/level1.svg}, \includesvg[height=10px]{\svgs/level4.svg} and \includesvg[height=10px]{\svgs/level6.svg}) give you a Specialty Card, while silver Levels (2, 3, 5, 7) give you an Ability Card.
 \end{itemize}
 \vfill\null

--- a/sections/introduction.tex
+++ b/sections/introduction.tex
@@ -13,8 +13,9 @@ The continent of Antagarich is under war as several different Factions, led by t
 \hyperlink{Heroes of Might and Magic III}{Brown colored hyperlinks} refer you to other parts of the rule book.
 \vfill
 \columnbreak
-\note{5}{Exceptions and notes with \hyperlink{Heroes of Might and Magic III}{amber colored hyperlinks} are explained in boxes like this one.}
-\note{6}{Conflicting rules changes on components follow this priority: Player Cards, Unit Cards, Town Boards, Mission Book, this rule book.}
+\note{10}{Exceptions and notes with \hyperlink{Heroes of Might and Magic III}{amber colored hyperlinks} are explained in boxes like this one.
+    \medskip
+Conflicting rules changes on components follow this priority: Player Cards, Unit Cards, Town Boards, Mission Book, this rule book.}
 \vfill
 \end{multicols}
 

--- a/sections/introduction.tex
+++ b/sections/introduction.tex
@@ -14,6 +14,7 @@ The continent of Antagarich is under war as several different Factions, led by t
 \vfill
 \columnbreak
 \note{5}{Exceptions and notes with \hyperlink{Heroes of Might and Magic III}{amber colored hyperlinks} are explained in boxes like this one.}
+\note{6}{Conflicting rules changes on components follow this priority: Player Cards, Unit Cards, Town Boards, Mission Book, this rule book.}
 \vfill
 \end{multicols}
 

--- a/sections/map_elements.tex
+++ b/sections/map_elements.tex
@@ -5,7 +5,7 @@
 Each Scenario is built using four types of Map Tiles.
 Players always begin on their Faction-Specific Starting (I) Tile.
 Other tiles may be placed and discovered as described on the next page.
-All face-down tiles should be selected randomly from the pool of possible Tiles as described by the Scenario and shuffled to keep their front side hidden.\par
+During the game's setup, all face-down tiles should be selected randomly from the pool of possible Tiles as described by the Scenario and shuffled to keep their front side hidden.\par
 The \textbf{roman numeral} of each tile describes the overall \textbf{difficulty of Neutral Units} on that tile, as well as the number of rewards players might expect to find on that Tile.
 Starting (I) Tiles are the easiest while Center (VI-VII) Tiles are the most difficult.\par
 
@@ -21,7 +21,7 @@ When your Hero moves to a Field, they must immediately Visit it, or
 first start a \hyperlink{Combat}{Combat} against the enemies guarding it before Visiting.
 Empty Fields\index{Empty Field} do nothing when Visited.
 Solid yellow lines on a Field's edge cannot be passed through.
-\hyperlink{Difficulty}{Roman numerals} written on a Field indicate that the Field is guarded by neutral enemies that must be fought to Visit it.\par
+\hyperlink{Difficulty}{Roman numerals} written on a Field indicate that the Field is guarded by Neutral enemies that must be fought to Visit it.\par
 \columnbreak
 \includegraphics[width=\linewidth]{\images/maptiles.png}
 \vfill
@@ -34,7 +34,7 @@ Solid yellow lines on a Field's edge cannot be passed through.
 
 \subsection*{\hypertarget{Categories}{Location Categories}}
 Visiting Fields provides Heroes with benefits such as gaining Resources or Cards (see \hyperlink{All}{All Map Locations}).
-There are three categories of Visitable Fields:
+There are three categories of Fields:
 \begin{itemize}
   \item \textbf{Visitable} – Once you Visit this field, place a Black Cube on it.
     Treat it as an Empty Field as long as it has a Black Cube.

--- a/sections/player_turns.tex
+++ b/sections/player_turns.tex
@@ -7,7 +7,7 @@ At the start of a player's Turn, that player refreshes their hand of Cards from 
 \begin{itemize}
   \item Discard any number of Cards from your hand.
 If your current hand exceeds your Hand Limit \includesvg[height=10px]{\svgs/hand.svg}, you must discard down to at least your Hand Limit.
-  \item Draw back to your Hand Limit.
+  \item You may then draw Cards up to your Hand Limit.
 \end{itemize}
 Your current Hand Limit\index{Hand Limit} depends on your Main Hero's \hyperlink{Level}{Level}.
 The beginning of your Turn is the only time your Hand Limit is checked.\par

--- a/sections/units.tex
+++ b/sections/units.tex
@@ -19,7 +19,7 @@ When you do so, you can instantly Recruit and Reinforce \textbf{any number} of t
 \textbf{Reinforcing} requires that your Town has a Citadel in addition to a Dwelling of that Unit's Level.\par
 
 \note{13}{
-  Any effects which instruct you to Reinforce \textbf{do not} require using up the Population Token nor owning a Citadel or any Dwellings.\par
+  Any effects which instruct you to Reinforce \textbf{do not} require spending your Population Token nor owning a Citadel or any Dwellings.\par
 
   \medskip
 
@@ -43,8 +43,8 @@ When you do so, you can instantly Recruit and Reinforce \textbf{any number} of t
 \includesvg[height=30px]{\svgs/defense.svg}\textbf{Defense} - The amount by which this Unit reduces the Attack damage it receives.
 Does not apply to damage received from Spells or other non-attack effects.\par
 \includesvg[height=30px]{\svgs/health_points.svg}\textbf{\hypertarget{HP}{HP}} - The maximum amount of damage a Unit can sustain before it is defeated.
-"Few" Units are discarded from Combat and its owner's Unit Deck when defeated.
-"Pack" Units are turned back to "Few" Units, with any excess damage placed on its "Few" side.
+"Few" Units are discarded from Combat and their owner's Unit Deck when defeated.
+"Pack" Units are turned back to "Few" Units, with any excess damage placed on their "Few" side.
 Units retain their "Few" or "Pack" status between Combats.
 All damage is healed from all Units at the end of Combat.\par
 \includesvg[height=30px]{\svgs/initiative.svg}{\hypertarget{Initiative}{\textbf{Initiative}}} - Determines when the Unit Activates during Combat.

--- a/sections/units.tex
+++ b/sections/units.tex
@@ -7,7 +7,7 @@
 Every Faction has access to \textbf{7 different Units}, each with unique stats and abilities.
 Units are necessary for winning Combat and fulfilling Scenario goals.
 Each Scenario's setup instructions indicate which Unit Cards should be included in your initial Unit Deck.
-This Deck should be kept near the Town Board, clearly separated from the rest of your Faction's Units.\par
+This Deck should be kept clearly separated from the rest of your Faction's Units.\par
 Each Faction Unit is double-sided, with a weaker “Few” side, and a stronger “Pack” side.
 “Few” units may be upgraded to “Packs” by \textbf{Reinforcing} them, while taking damage in Combat can subsequently reduce a Unit back to its “Few” side.
 Units should be always kept on their correct side when moved around or inspected.\par
@@ -19,7 +19,7 @@ When you do so, you can instantly Recruit and Reinforce \textbf{any number} of t
 \textbf{Reinforcing} requires that your Town has a Citadel in addition to a Dwelling of that Unit's Level.\par
 
 \note{13}{
-  Any effects which allow you to Reinforce outside of using the Population Token \textbf{do not} require a Citadel or any Dwellings.\par
+  Any effects which instruct you to Reinforce \textbf{do not} require using up the Population Token nor owning a Citadel or any Dwellings.\par
 
   \medskip
 
@@ -44,9 +44,9 @@ When you do so, you can instantly Recruit and Reinforce \textbf{any number} of t
 Does not apply to damage received from Spells or other non-attack effects.\par
 \includesvg[height=30px]{\svgs/health_points.svg}\textbf{\hypertarget{HP}{HP}} - The maximum amount of damage a Unit can sustain before it is defeated.
 "Few" Units are discarded from Combat and its owner's Unit Deck when defeated.
-"Pack" Units are turned back to "Few" units, with any excess damage placed on its "Few" side.
-After Combat, all damage is healed from all Units.
-Units retain their "Few" or "Pack" status between Combats.\par
+"Pack" Units are turned back to "Few" Units, with any excess damage placed on its "Few" side.
+Units retain their "Few" or "Pack" status between Combats.
+All damage is healed from all Units at the end of Combat.\par
 \includesvg[height=30px]{\svgs/initiative.svg}{\hypertarget{Initiative}{\textbf{Initiative}}} - Determines when the Unit Activates during Combat.
 Units with a higher Initiative Activate first.
 
@@ -85,7 +85,7 @@ There are three types of Units:
   \item \textbf{Ranged}\index{Ranged Units} \includesvg[height=10px]{\svgs/unit_ranged.svg} Units may attack \textbf{any Unit anywhere} and then move up to 1 space OR move up to 1 space without attacking.
 \end{itemize}
 If a \includesvg[height=10px]{\svgs/unit_ranged.svg} Unit is next to an enemy Unit, its attack target \textbf{must be} that adjacent enemy.
-When attacking an adjacent enemy in this way, the \includesvg[height=10px]{\svgs/unit_ranged.svg} Unit suffers a Combat penalty\index{Combat Penalty}: throw two Combat Dice (instead of one) and \textbf{apply the smaller result}.\par
+When attacking an adjacent enemy in this way, the \includesvg[height=10px]{\svgs/unit_ranged.svg} Unit suffers a Combat penalty\index{Combat Penalty}: throw two Attack Dice (instead of one) and \textbf{apply the smaller result}.\par
 This penalty is also applied if the \includesvg[height=10px]{\svgs/unit_ranged.svg} Unit attacks from its own backline into the enemy's backline.
 Walls and Gates may also \hyperlink{Walls}{reduce} the damage from  \includesvg[height=10px]{\svgs/unit_ranged.svg} attacks.
 


### PR DESCRIPTION
This PR addresses the following roadmap goals:
- Add a box about rules priority.
- Level ups are resolved before visiting a field.
- General timings of cards, and if you can use them outside of combat etc.
- Try to explain the use of +attack and +defense cards properly.
- Clarification: If AI heroes are instructed to draw a card, they draw another one from the AI deck.
- Drawing up to your hand limit at the start of your turn is actually optional, huh. It says "may" in the original. Added this.

Also, again, rewording minor things, Capitalizations etc.