### PR TITLE
Couple of touch ups

### DIFF
--- a/sections/all_map_locations.tex
+++ b/sections/all_map_locations.tex
@@ -11,11 +11,11 @@
   \begin{tabularx}{\linewidth}{Y m{0.7\linewidth}}
     \small
     \mbox{\textbf{I-VII}} & Field Difficulty corresponding to the level of Neutral Units. \\
-    \includesvg[height=15px]{\svgs/treasure.svg} & Roll a Treasure die and gain the indicated bouns. \\
-    \includesvg[height=15px]{\svgs/resource_die.svg} & Roll a Resource die and gain the indicated resources. \\
-    \includesvg[height=15px]{\svgs/experience.svg} & Gain one experience point. \\
-    \includesvg[height=15px]{\svgs/spellpower.svg} & Search (2) the Spell deck. \\
-    \includesvg[height=15px]{\svgs/artifact.svg} & Search (2) the Artifact deck. \\
+    \includesvg[height=15px]{\svgs/treasure.svg} & Roll a Treasure Die and gain the indicated bonus. \\
+    \includesvg[height=15px]{\svgs/resource_die.svg} & Roll a Resource Die and gain the indicated Resources. \\
+    \includesvg[height=15px]{\svgs/experience.svg} & Gain one Experience Point. \\
+    \includesvg[height=15px]{\svgs/spellpower.svg} & Search (2) the Spell Deck. \\
+    \includesvg[height=15px]{\svgs/artifact.svg} & Search (2) the Artifact Deck. \\
     \includesvg[height=15px]{\svgs/morale_positive.svg} & Gain Positive Morale. \\
     \includesvg[height=15px]{\svgs/morale_negative.svg} & Gain Negative Morale. \\
     \includesvg[height=15px]{\svgs/movement.svg} & Gain 1 Movement Point. \\
@@ -28,25 +28,25 @@
 \begin{itemize}[itemsep=1em]
   \item [{\LARGE\textbf{+}}]
     \includesvg[height=0.8\baselineskip]{\svgs/gold.svg}/\includesvg[height=0.8\baselineskip]{\svgs/building_materials.svg}/\includesvg[height=0.8\baselineskip]{\svgs/valuablegreater.svg} —
-    Immediately gain the given resource.
+    Immediately gain the indicated Resource.
   \item [{\includesvg[height=15px]{\svgs/ongoing.svg}}]
     \includesvg[height=0.8\baselineskip]{\svgs/gold.svg}/\includesvg[height=0.8\baselineskip]{\svgs/building_materials.svg}/\includesvg[height=0.8\baselineskip]{\svgs/valuablegreater.svg} —
-    Increase the production of the given resource.
+    Increase the production of the indicated Resource.
     If it is \textbf{Flagged} for the first time, you also gain it immediately.
   \item [{\includesvg[height=0.8\baselineskip]{\svgs/pay_v2.svg}}]
     \includesvg[height=0.8\baselineskip]{\svgs/gold.svg}/\includesvg[height=0.8\baselineskip]{\svgs/building_materials.svg}/\includesvg[height=0.8\baselineskip]{\svgs/valuablegreater.svg} \includesvg[height=0.8\baselineskip]{\svgs/arrow_right.svg} —
-    The Player needs to pay the given resource to gain something.
+    The Player needs to pay the indicated Resource to gain something.
   \item [{\LARGE\textbf{2}}] {\LARGE\textbf{x}} —
-    Perofm {\LARGE\textbf{x}} action twice.
-  \item [{\LARGE\textbf{2}}] \includesvg[height=0.8\baselineskip]{\svgs/treasure.svg} \includesvg[height=0.8\baselineskip]{\svgs/arrow_right.svg}{\LARGE\textbf{1}} —
-    Roll 2 Treasure dice and choose one to be resolved.
+    Perform the {\LARGE\textbf{x}} action twice.
+  \item [{\LARGE\textbf{2}}] \includesvg[height=0.8\baselineskip]{\svgs/treasure.svg}/{\LARGE\textbf{2}} \includesvg[height=0.8\baselineskip]{\svgs/resource_die.svg} \includesvg[height=0.8\baselineskip]{\svgs/arrow_right.svg}{\LARGE\textbf{1}} —
+    Roll 2 Treasure or Resource Dice and choose one to be resolved.
 \end{itemize}
 
 \phantom{\includesvg[height=1px]{\svgs/experience.svg}\includesvg[height=1px]{\svgs/spellpower.svg}}
 \vspace*{\fill}
 \columnbreak
 
-Effects of the following \textbf{Visitable} fields are explained by the symbols on the left:
+The effects of the following \textbf{Visitable} fields are explained by the symbols on the left:
 
 \medskip
 
@@ -154,9 +154,9 @@ All mines have the \includesvg[height=10px]{\svgs/ongoing.svg} symbol and a pict
 
 \textbf{Settlements}\index{Settlement} act as a spawn point for Secondary Heroes, and as a place for Main Heroes to move to when defeated.
 When you Flag a Settlement, choose whether to increase your \includesvg[height=10px]{\svgs/gold.svg}, \includesvg[height=10px]{\svgs/building_materials.svg} or \includesvg[height=10px]{\svgs/valuablegreater.svg} income by one space.
-As with Mines, if you are the first player to Flag a Settlement, you immediately gain Resources equal to that increase in production.
+As with Mines, if you are the first player to Flag a Settlement, you \textbf{immediately} gain Resources equal to that increase in production.
 Mark the Settlement with an appropriate Resource Token to show which Resource it produces.
-When you Flag an enemy Settlement, you may change which Resource it produces.\par
+When you Flag an enemy Settlement, you may change this Resource.\par
 Additionally, \textbf{instead of increasing Resource Production}, you may choose to \textbf{Reinforce} one of your \includesvg[height=10px]{\svgs/bronze.svg} or \includesvg[height=10px]{\svgs/silver.svg} Units immediately for half the normal cost, rounded up.
 If you were the first player to Flag the Settlement, Reinforce that Unit \textbf{for free} instead.
 Do not place any Resource Tokens on the Settlement if you choose to Reinforce.

--- a/sections/player_turns.tex
+++ b/sections/player_turns.tex
@@ -6,13 +6,15 @@
 At the start of your Turn, refresh your hand of Cards following these steps:
 \begin{itemize}
   \item Discard any number of Cards from your hand.
-If your current hand exceeds your Hand Limit \includesvg[height=10px]{\svgs/hand.svg}, you must discard down to match your Hand Limit.
+If your current hand exceeds your Hand Limit \includesvg[height=10px]{\svgs/hand.svg}, you must discard down to match the Limit.
   \item You may then draw Cards up to your Hand Limit.
+  \item Resolve any "at the beginning of your turn" abilities after drawing.
 \end{itemize}
 Your current Hand Limit\index{Hand Limit} depends on your Main Hero's \hyperlink{Level}{Level}.
 The beginning of your Turn is the only time your Hand Limit is checked.\par
 There are three types of Actions players may take: \textbf{Movement}, \textbf{Town}, and \textbf{Morale}.
 Once all players have spent all their Movement Points and do not wish to use any further Town or Morale Actions, the current Round is over.
+
 \subsection*{Movement Actions}
 \hypertarget{Movement}{Movement Actions}\index{Movement Actions} are performed by spending Movement Points.
 A player can use Movement Actions \textbf{only during their own Turn}.\par


### PR DESCRIPTION
Fixed a couple of new typoes. Added a bullet point to the start of turn section to clarify that "start of turn" abilities trigger after your card drawing is done.

Changed the "throw two dice and resolve one" symbols/description to be the same as what's on the pandora's box. I know there's fields where you just throw two treasure dice, but there's not really enough room to fit that all there. It should be clear what is meant when you see a field like that and also it's on the back of the original book. The original, however, does not explain pandora's box anywhere so it makes sense to cover it there.