### PR TITLE
Clarify inability to summon neutral units

### DIFF
--- a/sections/expansion_content.tex
+++ b/sections/expansion_content.tex
@@ -128,6 +128,7 @@ Any cards which were revealed as a part of resolving an Event should be shuffled
 
 \subsection*{Summoning}
 Some cards from the Inferno expansion may Summon Units\index{Summoning} during Combat.
+This effect cannot Summon Units from the Neutral Units Deck.
 Place the summoned Unit adjacent to the summoning Unit.
 Summoned Units Activate in the Round they were summoned if their Initiative is lower or equal to the Initiative of the currently Activated Unit.
 Otherwise, treat them as if they already activated this Combat Round.

--- a/translations/expansion_content.tex/cs.po
+++ b/translations/expansion_content.tex/cs.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Homm 3BG\n"
-"POT-Creation-Date: 2024-08-10 22:57+0200\n"
+"POT-Creation-Date: 2024-08-19 21:19+0200\n"
 "PO-Revision-Date: 2024-06-03 10:39+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -43,8 +43,8 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: sections/ai_rules.tex:32 sections/ai_rules.tex:104 sections/combat.tex:47
-#: sections/combat.tex:185 sections/expansion_content.tex:67
+#: sections/ai_rules.tex:32 sections/ai_rules.tex:104 sections/combat.tex:45
+#: sections/combat.tex:183 sections/expansion_content.tex:67
 #: sections/heroes.tex:34
 #, no-wrap
 msgid ""
@@ -345,11 +345,20 @@ msgstr ""
 "  "
 
 #. type: multicols*
-#: sections/expansion_content.tex:135
-#, no-wrap
+#: sections/expansion_content.tex:136
+#, fuzzy, no-wrap
+#| msgid ""
+#| "\\subsection*{Summoning}\n"
+#| "Some cards from the Inferno expansion may Summon Units\\index{Summoning} during Combat.\n"
+#| "Place the summoned Unit adjacent to the summoning Unit.\n"
+#| "Summoned Units Activate in the Round they were summoned if their Initiative is lower or equal to the Initiative of the currently Activated Unit.\n"
+#| "Otherwise, treat them as if they already activated this Combat Round.\n"
+#| "After Combat, unless stated otherwise, the Summoned Units are added to your Unit Deck.\n"
+#| "\n"
 msgid ""
 "\\subsection*{Summoning}\n"
 "Some cards from the Inferno expansion may Summon Units\\index{Summoning} during Combat.\n"
+"This effect cannot Summon Units from the Neutral Units Deck.\n"
 "Place the summoned Unit adjacent to the summoning Unit.\n"
 "Summoned Units Activate in the Round they were summoned if their Initiative is lower or equal to the Initiative of the currently Activated Unit.\n"
 "Otherwise, treat them as if they already activated this Combat Round.\n"
@@ -365,7 +374,7 @@ msgstr ""
 "\n"
 
 #. type: multicols*
-#: sections/expansion_content.tex:140
+#: sections/expansion_content.tex:141
 #, no-wrap
 msgid ""
 "\\subsection*{\\pagetarget{Empowered Statistic}{Empowered} Statistic Cards}\\index{Empowered Statistic Card}\n"
@@ -381,20 +390,20 @@ msgstr ""
 "\n"
 
 #. type: multicols*
-#: sections/expansion_content.tex:141
+#: sections/expansion_content.tex:142
 #, no-wrap
 msgid "\\begin{scriptsize}\n"
 msgstr ""
 
 #. type: figure
-#: sections/expansion_content.tex:142 sections/map_elements.tex:40
+#: sections/expansion_content.tex:143 sections/map_elements.tex:40
 #: sections/setup.tex:9
 #, no-wrap
 msgid "  \\begin{tikzpicture}\n"
 msgstr ""
 
 #. type: multicols*
-#: sections/expansion_content.tex:168
+#: sections/expansion_content.tex:169
 #, no-wrap
 msgid ""
 "    \\draw (-2, 0) node[inner sep=0] {\\makebox[0.47\\linewidth][c]{\\includegraphics[width=0.47\\linewidth]{\\cards/empowered_statistic.png}}};\n"
@@ -450,7 +459,7 @@ msgstr ""
 "  \\end{itemize}"
 
 #. type: multicols*
-#: sections/expansion_content.tex:172
+#: sections/expansion_content.tex:173
 #, no-wrap
 msgid ""
 "\\subsection*{Random Town}\\index{Random Town}\n"
@@ -462,7 +471,7 @@ msgstr ""
 "\n"
 
 #. type: multicols*
-#: sections/expansion_content.tex:178
+#: sections/expansion_content.tex:179
 #, no-wrap
 msgid ""
 "\\vfill\n"

--- a/translations/expansion_content.tex/de.po
+++ b/translations/expansion_content.tex/de.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Homm 3BG\n"
-"POT-Creation-Date: 2024-08-10 22:57+0200\n"
+"POT-Creation-Date: 2024-08-19 21:19+0200\n"
 "PO-Revision-Date: 2024-05-03 08:54+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -43,8 +43,8 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: sections/ai_rules.tex:32 sections/ai_rules.tex:104 sections/combat.tex:47
-#: sections/combat.tex:185 sections/expansion_content.tex:67
+#: sections/ai_rules.tex:32 sections/ai_rules.tex:104 sections/combat.tex:45
+#: sections/combat.tex:183 sections/expansion_content.tex:67
 #: sections/heroes.tex:34
 #, no-wrap
 msgid ""
@@ -257,11 +257,12 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: sections/expansion_content.tex:135
+#: sections/expansion_content.tex:136
 #, no-wrap
 msgid ""
 "\\subsection*{Summoning}\n"
 "Some cards from the Inferno expansion may Summon Units\\index{Summoning} during Combat.\n"
+"This effect cannot Summon Units from the Neutral Units Deck.\n"
 "Place the summoned Unit adjacent to the summoning Unit.\n"
 "Summoned Units Activate in the Round they were summoned if their Initiative is lower or equal to the Initiative of the currently Activated Unit.\n"
 "Otherwise, treat them as if they already activated this Combat Round.\n"
@@ -270,7 +271,7 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: sections/expansion_content.tex:140
+#: sections/expansion_content.tex:141
 #, no-wrap
 msgid ""
 "\\subsection*{\\pagetarget{Empowered Statistic}{Empowered} Statistic Cards}\\index{Empowered Statistic Card}\n"
@@ -281,20 +282,20 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: sections/expansion_content.tex:141
+#: sections/expansion_content.tex:142
 #, no-wrap
 msgid "\\begin{scriptsize}\n"
 msgstr ""
 
 #. type: figure
-#: sections/expansion_content.tex:142 sections/map_elements.tex:40
+#: sections/expansion_content.tex:143 sections/map_elements.tex:40
 #: sections/setup.tex:9
 #, no-wrap
 msgid "  \\begin{tikzpicture}\n"
 msgstr ""
 
 #. type: multicols*
-#: sections/expansion_content.tex:168
+#: sections/expansion_content.tex:169
 #, no-wrap
 msgid ""
 "    \\draw (-2, 0) node[inner sep=0] {\\makebox[0.47\\linewidth][c]{\\includegraphics[width=0.47\\linewidth]{\\cards/empowered_statistic.png}}};\n"
@@ -325,7 +326,7 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: sections/expansion_content.tex:172
+#: sections/expansion_content.tex:173
 #, no-wrap
 msgid ""
 "\\subsection*{Random Town}\\index{Random Town}\n"
@@ -334,7 +335,7 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: sections/expansion_content.tex:178
+#: sections/expansion_content.tex:179
 #, no-wrap
 msgid ""
 "\\vfill\n"

--- a/translations/expansion_content.tex/es.po
+++ b/translations/expansion_content.tex/es.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Homm 3BG\n"
-"POT-Creation-Date: 2024-08-10 22:57+0200\n"
+"POT-Creation-Date: 2024-08-19 21:19+0200\n"
 "PO-Revision-Date: 2024-04-15 17:20+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -43,8 +43,8 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: sections/ai_rules.tex:32 sections/ai_rules.tex:104 sections/combat.tex:47
-#: sections/combat.tex:185 sections/expansion_content.tex:67
+#: sections/ai_rules.tex:32 sections/ai_rules.tex:104 sections/combat.tex:45
+#: sections/combat.tex:183 sections/expansion_content.tex:67
 #: sections/heroes.tex:34
 #, no-wrap
 msgid ""
@@ -341,11 +341,20 @@ msgstr ""
 "  "
 
 #. type: multicols*
-#: sections/expansion_content.tex:135
-#, no-wrap
+#: sections/expansion_content.tex:136
+#, fuzzy, no-wrap
+#| msgid ""
+#| "\\subsection*{Summoning}\n"
+#| "Some cards from the Inferno expansion may Summon Units\\index{Summoning} during Combat.\n"
+#| "Place the summoned Unit adjacent to the summoning Unit.\n"
+#| "Summoned Units Activate in the Round they were summoned if their Initiative is lower or equal to the Initiative of the currently Activated Unit.\n"
+#| "Otherwise, treat them as if they already activated this Combat Round.\n"
+#| "After Combat, unless stated otherwise, the Summoned Units are added to your Unit Deck.\n"
+#| "\n"
 msgid ""
 "\\subsection*{Summoning}\n"
 "Some cards from the Inferno expansion may Summon Units\\index{Summoning} during Combat.\n"
+"This effect cannot Summon Units from the Neutral Units Deck.\n"
 "Place the summoned Unit adjacent to the summoning Unit.\n"
 "Summoned Units Activate in the Round they were summoned if their Initiative is lower or equal to the Initiative of the currently Activated Unit.\n"
 "Otherwise, treat them as if they already activated this Combat Round.\n"
@@ -361,7 +370,7 @@ msgstr ""
 "\n"
 
 #. type: multicols*
-#: sections/expansion_content.tex:140
+#: sections/expansion_content.tex:141
 #, no-wrap
 msgid ""
 "\\subsection*{\\pagetarget{Empowered Statistic}{Empowered} Statistic Cards}\\index{Empowered Statistic Card}\n"
@@ -377,20 +386,20 @@ msgstr ""
 "\n"
 
 #. type: multicols*
-#: sections/expansion_content.tex:141
+#: sections/expansion_content.tex:142
 #, no-wrap
 msgid "\\begin{scriptsize}\n"
 msgstr ""
 
 #. type: figure
-#: sections/expansion_content.tex:142 sections/map_elements.tex:40
+#: sections/expansion_content.tex:143 sections/map_elements.tex:40
 #: sections/setup.tex:9
 #, no-wrap
 msgid "  \\begin{tikzpicture}\n"
 msgstr ""
 
 #. type: multicols*
-#: sections/expansion_content.tex:168
+#: sections/expansion_content.tex:169
 #, no-wrap
 msgid ""
 "    \\draw (-2, 0) node[inner sep=0] {\\makebox[0.47\\linewidth][c]{\\includegraphics[width=0.47\\linewidth]{\\cards/empowered_statistic.png}}};\n"
@@ -446,7 +455,7 @@ msgstr ""
 "  \\end{itemize}"
 
 #. type: multicols*
-#: sections/expansion_content.tex:172
+#: sections/expansion_content.tex:173
 #, no-wrap
 msgid ""
 "\\subsection*{Random Town}\\index{Random Town}\n"
@@ -458,7 +467,7 @@ msgstr ""
 "\n"
 
 #. type: multicols*
-#: sections/expansion_content.tex:178
+#: sections/expansion_content.tex:179
 #, no-wrap
 msgid ""
 "\\vfill\n"

--- a/translations/expansion_content.tex/expansion_content.tex.pot
+++ b/translations/expansion_content.tex/expansion_content.tex.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-08-10 22:57+0200\n"
+"POT-Creation-Date: 2024-08-19 21:19+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -43,8 +43,8 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: sections/ai_rules.tex:32 sections/ai_rules.tex:104 sections/combat.tex:47
-#: sections/combat.tex:185 sections/expansion_content.tex:67
+#: sections/ai_rules.tex:32 sections/ai_rules.tex:104 sections/combat.tex:45
+#: sections/combat.tex:183 sections/expansion_content.tex:67
 #: sections/heroes.tex:34
 #, no-wrap
 msgid ""
@@ -257,11 +257,12 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: sections/expansion_content.tex:135
+#: sections/expansion_content.tex:136
 #, no-wrap
 msgid ""
 "\\subsection*{Summoning}\n"
 "Some cards from the Inferno expansion may Summon Units\\index{Summoning} during Combat.\n"
+"This effect cannot Summon Units from the Neutral Units Deck.\n"
 "Place the summoned Unit adjacent to the summoning Unit.\n"
 "Summoned Units Activate in the Round they were summoned if their Initiative is lower or equal to the Initiative of the currently Activated Unit.\n"
 "Otherwise, treat them as if they already activated this Combat Round.\n"
@@ -270,7 +271,7 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: sections/expansion_content.tex:140
+#: sections/expansion_content.tex:141
 #, no-wrap
 msgid ""
 "\\subsection*{\\pagetarget{Empowered Statistic}{Empowered} Statistic Cards}\\index{Empowered Statistic Card}\n"
@@ -281,20 +282,20 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: sections/expansion_content.tex:141
+#: sections/expansion_content.tex:142
 #, no-wrap
 msgid "\\begin{scriptsize}\n"
 msgstr ""
 
 #. type: figure
-#: sections/expansion_content.tex:142 sections/map_elements.tex:40
+#: sections/expansion_content.tex:143 sections/map_elements.tex:40
 #: sections/setup.tex:9
 #, no-wrap
 msgid "  \\begin{tikzpicture}\n"
 msgstr ""
 
 #. type: multicols*
-#: sections/expansion_content.tex:168
+#: sections/expansion_content.tex:169
 #, no-wrap
 msgid ""
 "    \\draw (-2, 0) node[inner sep=0] {\\makebox[0.47\\linewidth][c]{\\includegraphics[width=0.47\\linewidth]{\\cards/empowered_statistic.png}}};\n"
@@ -325,7 +326,7 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: sections/expansion_content.tex:172
+#: sections/expansion_content.tex:173
 #, no-wrap
 msgid ""
 "\\subsection*{Random Town}\\index{Random Town}\n"
@@ -334,7 +335,7 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: sections/expansion_content.tex:178
+#: sections/expansion_content.tex:179
 #, no-wrap
 msgid ""
 "\\vfill\n"

--- a/translations/expansion_content.tex/fr.po
+++ b/translations/expansion_content.tex/fr.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Homm 3BG\n"
-"POT-Creation-Date: 2024-08-10 22:57+0200\n"
+"POT-Creation-Date: 2024-08-19 21:19+0200\n"
 "PO-Revision-Date: 2024-04-06 18:37+0300\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -45,8 +45,8 @@ msgstr ""
 "\n"
 
 #. type: multicols*
-#: sections/ai_rules.tex:32 sections/ai_rules.tex:104 sections/combat.tex:47
-#: sections/combat.tex:185 sections/expansion_content.tex:67
+#: sections/ai_rules.tex:32 sections/ai_rules.tex:104 sections/combat.tex:45
+#: sections/combat.tex:183 sections/expansion_content.tex:67
 #: sections/heroes.tex:34
 #, no-wrap
 msgid ""
@@ -347,11 +347,20 @@ msgstr ""
 "  "
 
 #. type: multicols*
-#: sections/expansion_content.tex:135
-#, no-wrap
+#: sections/expansion_content.tex:136
+#, fuzzy, no-wrap
+#| msgid ""
+#| "\\subsection*{Summoning}\n"
+#| "Some cards from the Inferno expansion may Summon Units\\index{Summoning} during Combat.\n"
+#| "Place the summoned Unit adjacent to the summoning Unit.\n"
+#| "Summoned Units Activate in the Round they were summoned if their Initiative is lower or equal to the Initiative of the currently Activated Unit.\n"
+#| "Otherwise, treat them as if they already activated this Combat Round.\n"
+#| "After Combat, unless stated otherwise, the Summoned Units are added to your Unit Deck.\n"
+#| "\n"
 msgid ""
 "\\subsection*{Summoning}\n"
 "Some cards from the Inferno expansion may Summon Units\\index{Summoning} during Combat.\n"
+"This effect cannot Summon Units from the Neutral Units Deck.\n"
 "Place the summoned Unit adjacent to the summoning Unit.\n"
 "Summoned Units Activate in the Round they were summoned if their Initiative is lower or equal to the Initiative of the currently Activated Unit.\n"
 "Otherwise, treat them as if they already activated this Combat Round.\n"
@@ -367,7 +376,7 @@ msgstr ""
 "\n"
 
 #. type: multicols*
-#: sections/expansion_content.tex:140
+#: sections/expansion_content.tex:141
 #, fuzzy, no-wrap
 #| msgid ""
 #| "\\subsection*{\\pagetarget{Empowered Statistic}{Empowered} Statistic Cards}\\index{Empowered Statistic Card}\n"
@@ -389,20 +398,20 @@ msgstr ""
 "\n"
 
 #. type: multicols*
-#: sections/expansion_content.tex:141
+#: sections/expansion_content.tex:142
 #, no-wrap
 msgid "\\begin{scriptsize}\n"
 msgstr ""
 
 #. type: figure
-#: sections/expansion_content.tex:142 sections/map_elements.tex:40
+#: sections/expansion_content.tex:143 sections/map_elements.tex:40
 #: sections/setup.tex:9
 #, no-wrap
 msgid "  \\begin{tikzpicture}\n"
 msgstr ""
 
 #. type: multicols*
-#: sections/expansion_content.tex:168
+#: sections/expansion_content.tex:169
 #, no-wrap
 msgid ""
 "    \\draw (-2, 0) node[inner sep=0] {\\makebox[0.47\\linewidth][c]{\\includegraphics[width=0.47\\linewidth]{\\cards/empowered_statistic.png}}};\n"
@@ -458,7 +467,7 @@ msgstr ""
 "  \\end{itemize}"
 
 #. type: multicols*
-#: sections/expansion_content.tex:172
+#: sections/expansion_content.tex:173
 #, no-wrap
 msgid ""
 "\\subsection*{Random Town}\\index{Random Town}\n"
@@ -470,7 +479,7 @@ msgstr ""
 "\n"
 
 #. type: multicols*
-#: sections/expansion_content.tex:178
+#: sections/expansion_content.tex:179
 #, no-wrap
 msgid ""
 "\\vfill\n"

--- a/translations/expansion_content.tex/he.po
+++ b/translations/expansion_content.tex/he.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Homm 3BG\n"
-"POT-Creation-Date: 2024-08-10 22:57+0200\n"
+"POT-Creation-Date: 2024-08-19 21:19+0200\n"
 "PO-Revision-Date: 2024-06-03 10:39+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -43,8 +43,8 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: sections/ai_rules.tex:32 sections/ai_rules.tex:104 sections/combat.tex:47
-#: sections/combat.tex:185 sections/expansion_content.tex:67
+#: sections/ai_rules.tex:32 sections/ai_rules.tex:104 sections/combat.tex:45
+#: sections/combat.tex:183 sections/expansion_content.tex:67
 #: sections/heroes.tex:34
 #, no-wrap
 msgid ""
@@ -257,11 +257,12 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: sections/expansion_content.tex:135
+#: sections/expansion_content.tex:136
 #, no-wrap
 msgid ""
 "\\subsection*{Summoning}\n"
 "Some cards from the Inferno expansion may Summon Units\\index{Summoning} during Combat.\n"
+"This effect cannot Summon Units from the Neutral Units Deck.\n"
 "Place the summoned Unit adjacent to the summoning Unit.\n"
 "Summoned Units Activate in the Round they were summoned if their Initiative is lower or equal to the Initiative of the currently Activated Unit.\n"
 "Otherwise, treat them as if they already activated this Combat Round.\n"
@@ -270,7 +271,7 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: sections/expansion_content.tex:140
+#: sections/expansion_content.tex:141
 #, no-wrap
 msgid ""
 "\\subsection*{\\pagetarget{Empowered Statistic}{Empowered} Statistic Cards}\\index{Empowered Statistic Card}\n"
@@ -281,20 +282,20 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: sections/expansion_content.tex:141
+#: sections/expansion_content.tex:142
 #, no-wrap
 msgid "\\begin{scriptsize}\n"
 msgstr ""
 
 #. type: figure
-#: sections/expansion_content.tex:142 sections/map_elements.tex:40
+#: sections/expansion_content.tex:143 sections/map_elements.tex:40
 #: sections/setup.tex:9
 #, no-wrap
 msgid "  \\begin{tikzpicture}\n"
 msgstr ""
 
 #. type: multicols*
-#: sections/expansion_content.tex:168
+#: sections/expansion_content.tex:169
 #, no-wrap
 msgid ""
 "    \\draw (-2, 0) node[inner sep=0] {\\makebox[0.47\\linewidth][c]{\\includegraphics[width=0.47\\linewidth]{\\cards/empowered_statistic.png}}};\n"
@@ -325,7 +326,7 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: sections/expansion_content.tex:172
+#: sections/expansion_content.tex:173
 #, no-wrap
 msgid ""
 "\\subsection*{Random Town}\\index{Random Town}\n"
@@ -334,7 +335,7 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: sections/expansion_content.tex:178
+#: sections/expansion_content.tex:179
 #, no-wrap
 msgid ""
 "\\vfill\n"

--- a/translations/expansion_content.tex/pl.po
+++ b/translations/expansion_content.tex/pl.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Homm 3BG\n"
-"POT-Creation-Date: 2024-08-10 22:57+0200\n"
+"POT-Creation-Date: 2024-08-19 21:19+0200\n"
 "PO-Revision-Date: 2024-04-06 18:37+0300\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -45,8 +45,8 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: sections/ai_rules.tex:32 sections/ai_rules.tex:104 sections/combat.tex:47
-#: sections/combat.tex:185 sections/expansion_content.tex:67
+#: sections/ai_rules.tex:32 sections/ai_rules.tex:104 sections/combat.tex:45
+#: sections/combat.tex:183 sections/expansion_content.tex:67
 #: sections/heroes.tex:34
 #, no-wrap
 msgid ""
@@ -299,13 +299,13 @@ msgid ""
 "\n"
 msgstr ""
 "\\subsection*{\\pagetarget{Events}{Wydarzenia}}\n"
-"Dodane przez rozszerzenie Cytadela.\n"
+"Dodane w rozszerzeniu Cytadela.\n"
 "Karty Wydarzeń\\index{Karta!Wydarzeń} mogą być używane w grach wieloosobowych.\n"
-"Talię Wydarzeń należy potasować podczas przygotowania do gry.\n"
-"Na początku każdej Rundy Zasobów (z wyjątkiem pierwszej) dobierz i przeczytaj kolejną Kartę Wydarzenia po otrzymaniu Zasobów.\n"
+"Potasuj Talię Wydarzeń podczas przygotowania gry.\n"
+"Na początku każdej Rundy Zasobów (z wyjątkiem pierwszej), po otrzymaniu Zasobów, dobierz i przeczytaj kolejną Kartę Wydarzenia.\n"
 "Pierwsze Wydarzenie jest dobierane przez gracza rozpoczynającego. \\textbf{Należy zmieniać gracza, który dobiera kolejne Wydarzenie, zgodnie z ruchem wskazówek zegara}.\n"
-"Wszelkie efekty należy rozpatrywać w takiej samej kolejności, zaczynając od gracza, który dobrał Kartę.\n"
-"Wszelkie karty, które zostały ujawnione w ramach rozpatrywania Wydarzenia, należy wtasować z powrotem do ich talii.\n"
+"Rozpatruj wszelkie efekty w takiej samej kolejności, zaczynając od gracza, który dobrał Kartę.\n"
+"Karty odkryte w ramach rozpatrywania Wydarzenia należy wtasować z powrotem do ich Talii.\n"
 "\n"
 
 #. type: multicols*
@@ -347,11 +347,12 @@ msgstr ""
 "  "
 
 #. type: multicols*
-#: sections/expansion_content.tex:135
+#: sections/expansion_content.tex:136
 #, no-wrap
 msgid ""
 "\\subsection*{Summoning}\n"
 "Some cards from the Inferno expansion may Summon Units\\index{Summoning} during Combat.\n"
+"This effect cannot Summon Units from the Neutral Units Deck.\n"
 "Place the summoned Unit adjacent to the summoning Unit.\n"
 "Summoned Units Activate in the Round they were summoned if their Initiative is lower or equal to the Initiative of the currently Activated Unit.\n"
 "Otherwise, treat them as if they already activated this Combat Round.\n"
@@ -360,6 +361,7 @@ msgid ""
 msgstr ""
 "\\subsection*{Przyzwanie}\n"
 "Niektóre Karty z rozszerzenia Inferno mogą Przyzwać\\index{Przyzwanie} Jednostki podczas Walki.\n"
+"Tym efektem nie można Przyzywać Jednostek z Talii Jednostek Neutralnych.\n"
 "Przyzwaną Jednostkę należy umieścić obok Jednostki, która Przyzwała.\n"
 "Przyzwane Jednostki Aktywują się w Rundzie, w której je przyzwano, jeśli ich Inicjatywa jest niższa lub równa Inicjatywie aktualnie Aktywowanej Jednostki.\n"
 "W przeciwnym razie traktuj je tak, jakby już aktywowały się w tej Rundzie Walki.\n"
@@ -367,7 +369,7 @@ msgstr ""
 "\n"
 
 #. type: multicols*
-#: sections/expansion_content.tex:140
+#: sections/expansion_content.tex:141
 #, no-wrap
 msgid ""
 "\\subsection*{\\pagetarget{Empowered Statistic}{Empowered} Statistic Cards}\\index{Empowered Statistic Card}\n"
@@ -383,20 +385,20 @@ msgstr ""
 "\n"
 
 #. type: multicols*
-#: sections/expansion_content.tex:141
+#: sections/expansion_content.tex:142
 #, no-wrap
 msgid "\\begin{scriptsize}\n"
 msgstr ""
 
 #. type: figure
-#: sections/expansion_content.tex:142 sections/map_elements.tex:40
+#: sections/expansion_content.tex:143 sections/map_elements.tex:40
 #: sections/setup.tex:9
 #, no-wrap
 msgid "  \\begin{tikzpicture}\n"
 msgstr ""
 
 #. type: multicols*
-#: sections/expansion_content.tex:168
+#: sections/expansion_content.tex:169
 #, no-wrap
 msgid ""
 "    \\draw (-2, 0) node[inner sep=0] {\\makebox[0.47\\linewidth][c]{\\includegraphics[width=0.47\\linewidth]{\\cards/empowered_statistic.png}}};\n"
@@ -452,7 +454,7 @@ msgstr ""
 "  \\end{itemize}"
 
 #. type: multicols*
-#: sections/expansion_content.tex:172
+#: sections/expansion_content.tex:173
 #, no-wrap
 msgid ""
 "\\subsection*{Random Town}\\index{Random Town}\n"
@@ -464,7 +466,7 @@ msgstr ""
 "\n"
 
 #. type: multicols*
-#: sections/expansion_content.tex:178
+#: sections/expansion_content.tex:179
 #, no-wrap
 msgid ""
 "\\vfill\n"

--- a/translations/expansion_content.tex/ru.po
+++ b/translations/expansion_content.tex/ru.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Homm 3BG\n"
-"POT-Creation-Date: 2024-08-10 22:57+0200\n"
+"POT-Creation-Date: 2024-08-19 21:19+0200\n"
 "PO-Revision-Date: 2024-04-23 15:23+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -45,8 +45,8 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: sections/ai_rules.tex:32 sections/ai_rules.tex:104 sections/combat.tex:47
-#: sections/combat.tex:185 sections/expansion_content.tex:67
+#: sections/ai_rules.tex:32 sections/ai_rules.tex:104 sections/combat.tex:45
+#: sections/combat.tex:183 sections/expansion_content.tex:67
 #: sections/heroes.tex:34
 #, no-wrap
 msgid ""
@@ -347,11 +347,20 @@ msgstr ""
 "  "
 
 #. type: multicols*
-#: sections/expansion_content.tex:135
-#, no-wrap
+#: sections/expansion_content.tex:136
+#, fuzzy, no-wrap
+#| msgid ""
+#| "\\subsection*{Summoning}\n"
+#| "Some cards from the Inferno expansion may Summon Units\\index{Summoning} during Combat.\n"
+#| "Place the summoned Unit adjacent to the summoning Unit.\n"
+#| "Summoned Units Activate in the Round they were summoned if their Initiative is lower or equal to the Initiative of the currently Activated Unit.\n"
+#| "Otherwise, treat them as if they already activated this Combat Round.\n"
+#| "After Combat, unless stated otherwise, the Summoned Units are added to your Unit Deck.\n"
+#| "\n"
 msgid ""
 "\\subsection*{Summoning}\n"
 "Some cards from the Inferno expansion may Summon Units\\index{Summoning} during Combat.\n"
+"This effect cannot Summon Units from the Neutral Units Deck.\n"
 "Place the summoned Unit adjacent to the summoning Unit.\n"
 "Summoned Units Activate in the Round they were summoned if their Initiative is lower or equal to the Initiative of the currently Activated Unit.\n"
 "Otherwise, treat them as if they already activated this Combat Round.\n"
@@ -367,7 +376,7 @@ msgstr ""
 "\n"
 
 #. type: multicols*
-#: sections/expansion_content.tex:140
+#: sections/expansion_content.tex:141
 #, fuzzy, no-wrap
 #| msgid ""
 #| "\\subsection*{\\pagetarget{Empowered Statistic}{Empowered} Statistic Cards}\\index{Empowered Statistic Card}\n"
@@ -389,20 +398,20 @@ msgstr ""
 "\n"
 
 #. type: multicols*
-#: sections/expansion_content.tex:141
+#: sections/expansion_content.tex:142
 #, no-wrap
 msgid "\\begin{scriptsize}\n"
 msgstr ""
 
 #. type: figure
-#: sections/expansion_content.tex:142 sections/map_elements.tex:40
+#: sections/expansion_content.tex:143 sections/map_elements.tex:40
 #: sections/setup.tex:9
 #, no-wrap
 msgid "  \\begin{tikzpicture}\n"
 msgstr ""
 
 #. type: multicols*
-#: sections/expansion_content.tex:168
+#: sections/expansion_content.tex:169
 #, no-wrap
 msgid ""
 "    \\draw (-2, 0) node[inner sep=0] {\\makebox[0.47\\linewidth][c]{\\includegraphics[width=0.47\\linewidth]{\\cards/empowered_statistic.png}}};\n"
@@ -458,7 +467,7 @@ msgstr ""
 "  \\end{itemize}"
 
 #. type: multicols*
-#: sections/expansion_content.tex:172
+#: sections/expansion_content.tex:173
 #, no-wrap
 msgid ""
 "\\subsection*{Random Town}\\index{Random Town}\n"
@@ -470,7 +479,7 @@ msgstr ""
 "\n"
 
 #. type: multicols*
-#: sections/expansion_content.tex:178
+#: sections/expansion_content.tex:179
 #, no-wrap
 msgid ""
 "\\vfill\n"

--- a/translations/expansion_content.tex/ua.po
+++ b/translations/expansion_content.tex/ua.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Homm 3BG\n"
-"POT-Creation-Date: 2024-08-10 22:57+0200\n"
+"POT-Creation-Date: 2024-08-19 21:19+0200\n"
 "PO-Revision-Date: 2024-05-13 17:32+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -43,8 +43,8 @@ msgid ""
 msgstr ""
 
 #. type: multicols*
-#: sections/ai_rules.tex:32 sections/ai_rules.tex:104 sections/combat.tex:47
-#: sections/combat.tex:185 sections/expansion_content.tex:67
+#: sections/ai_rules.tex:32 sections/ai_rules.tex:104 sections/combat.tex:45
+#: sections/combat.tex:183 sections/expansion_content.tex:67
 #: sections/heroes.tex:34
 #, no-wrap
 msgid ""
@@ -345,11 +345,20 @@ msgstr ""
 "  "
 
 #. type: multicols*
-#: sections/expansion_content.tex:135
-#, no-wrap
+#: sections/expansion_content.tex:136
+#, fuzzy, no-wrap
+#| msgid ""
+#| "\\subsection*{Summoning}\n"
+#| "Some cards from the Inferno expansion may Summon Units\\index{Summoning} during Combat.\n"
+#| "Place the summoned Unit adjacent to the summoning Unit.\n"
+#| "Summoned Units Activate in the Round they were summoned if their Initiative is lower or equal to the Initiative of the currently Activated Unit.\n"
+#| "Otherwise, treat them as if they already activated this Combat Round.\n"
+#| "After Combat, unless stated otherwise, the Summoned Units are added to your Unit Deck.\n"
+#| "\n"
 msgid ""
 "\\subsection*{Summoning}\n"
 "Some cards from the Inferno expansion may Summon Units\\index{Summoning} during Combat.\n"
+"This effect cannot Summon Units from the Neutral Units Deck.\n"
 "Place the summoned Unit adjacent to the summoning Unit.\n"
 "Summoned Units Activate in the Round they were summoned if their Initiative is lower or equal to the Initiative of the currently Activated Unit.\n"
 "Otherwise, treat them as if they already activated this Combat Round.\n"
@@ -365,7 +374,7 @@ msgstr ""
 "\n"
 
 #. type: multicols*
-#: sections/expansion_content.tex:140
+#: sections/expansion_content.tex:141
 #, fuzzy, no-wrap
 #| msgid ""
 #| "\\subsection*{\\pagetarget{Empowered Statistic}{Empowered} Statistic Cards}\\index{Empowered Statistic Card}\n"
@@ -387,20 +396,20 @@ msgstr ""
 "\n"
 
 #. type: multicols*
-#: sections/expansion_content.tex:141
+#: sections/expansion_content.tex:142
 #, no-wrap
 msgid "\\begin{scriptsize}\n"
 msgstr ""
 
 #. type: figure
-#: sections/expansion_content.tex:142 sections/map_elements.tex:40
+#: sections/expansion_content.tex:143 sections/map_elements.tex:40
 #: sections/setup.tex:9
 #, no-wrap
 msgid "  \\begin{tikzpicture}\n"
 msgstr ""
 
 #. type: multicols*
-#: sections/expansion_content.tex:168
+#: sections/expansion_content.tex:169
 #, no-wrap
 msgid ""
 "    \\draw (-2, 0) node[inner sep=0] {\\makebox[0.47\\linewidth][c]{\\includegraphics[width=0.47\\linewidth]{\\cards/empowered_statistic.png}}};\n"
@@ -456,7 +465,7 @@ msgstr ""
 "  \\end{itemize}"
 
 #. type: multicols*
-#: sections/expansion_content.tex:172
+#: sections/expansion_content.tex:173
 #, no-wrap
 msgid ""
 "\\subsection*{Random Town}\\index{Random Town}\n"
@@ -468,7 +477,7 @@ msgstr ""
 "\n"
 
 #. type: multicols*
-#: sections/expansion_content.tex:178
+#: sections/expansion_content.tex:179
 #, no-wrap
 msgid ""
 "\\vfill\n"


### PR DESCRIPTION
Including info, that neturals cannot be summoned:
![image](https://github.com/user-attachments/assets/98f27ff0-0dfd-4c2e-85a4-d0f55de4dcdc)

English:
![en-44](https://github.com/user-attachments/assets/ebac3b98-d0c2-4d24-8dca-b8fc7ffbb202)

Polish (with a slight rewording to maintain structure):
![pl-44](https://github.com/user-attachments/assets/4cb27751-c884-4fe6-875b-8f3e7760eef9)
