### PR TITLE
Translated inability to summon neutral units clarification.

### DIFF
--- a/translations/expansion_content.tex/es.po
+++ b/translations/expansion_content.tex/es.po
@@ -295,11 +295,11 @@ msgstr ""
 "\\subsection*{\\pagetarget{Events}{Eventos}}\n"
 "Las Cartas de Eventos\\index{Cartas de Eventos} pueden utilizarse en juegos con más de un jugador.\n"
 "Baraja el Mazo de Eventos durante la preparación.\n"
-"Al comienzo de cada Ronda de Recursos (excepto la primera Ronda), roba y lee la una Carta de Eventos después de recibir los Recursos.\n"
+"Al comienzo de cada Ronda de Recursos (excepto la primera Ronda), roba y lee una Carta de Eventos después de recibir los Recursos.\n"
 "El primer Evento lo hace el jugador inicial.\n"
 "\\textbf{Cambia el jugador que inicia el Evento en el sentido de las agujas del reloj} cada vez que se roba la Carta.\n"
 "Resuelve los efectos en el sentido de las agujas del reloj, empezando por el jugador que robó la carta.\n"
-"Cualquier carta que haya sido revelada como parte de la resolución de un Evento debe ser barajada de nuevo en su respectivo Mazo al acabar.\n"
+"Cualquier carta que haya sido revelada como parte de la resolución de un Evento debe ser barajada en su respectivo Mazo al acabar.\n"
 "\n"
 
 #. type: multicols*
@@ -342,15 +342,7 @@ msgstr ""
 
 #. type: multicols*
 #: sections/expansion_content.tex:136
-#, fuzzy, no-wrap
-#| msgid ""
-#| "\\subsection*{Summoning}\n"
-#| "Some cards from the Inferno expansion may Summon Units\\index{Summoning} during Combat.\n"
-#| "Place the summoned Unit adjacent to the summoning Unit.\n"
-#| "Summoned Units Activate in the Round they were summoned if their Initiative is lower or equal to the Initiative of the currently Activated Unit.\n"
-#| "Otherwise, treat them as if they already activated this Combat Round.\n"
-#| "After Combat, unless stated otherwise, the Summoned Units are added to your Unit Deck.\n"
-#| "\n"
+#, no-wrap
 msgid ""
 "\\subsection*{Summoning}\n"
 "Some cards from the Inferno expansion may Summon Units\\index{Summoning} during Combat.\n"
@@ -363,9 +355,10 @@ msgid ""
 msgstr ""
 "\\subsection*{Invocando}\n"
 "Algunas cartas de la expansión Infierno pueden Invocar Unidades\\index{Invocaciones} durante el combate.\n"
+"Este efecto no puede Invocar Unidades del Mazo de Unidades Neutrales.\n"
 "Coloca la Unidad invocada adyacente a la Unidad invocadora.\n"
 "Las Unidades Invocadas se Activan en la Ronda en la que fueron invocadas si su Iniciativa es menor o igual que la Iniciativa de la Unidad Activada en ese momento.\n"
-"En otro caso se tratarán como ya invocadas.\n"
+"En otro caso se tratarán como ya activadas.\n"
 "Después del Combate, a menos que se indique lo contrario, las Unidades Invocadas se añaden a tu Mazo de Unidades.\n"
 "\n"
 


### PR DESCRIPTION
Translated recent clarification from #663
![image](https://github.com/user-attachments/assets/e1384e5d-ac4a-45a6-930a-2fd6a6aedd21)
Had to reword the previous paragraph to mantain structure. Deleted a misplaced spanish "la" article.
![image](https://github.com/user-attachments/assets/319a4399-c63e-4dd1-81fa-8bd0f5b49a6d)
