### PR TITLE
Add test for broken cmap

### DIFF
--- a/.github/workflows/build-and-publish-rule-book.yaml
+++ b/.github/workflows/build-and-publish-rule-book.yaml
@@ -99,7 +99,11 @@ jobs:
       - name: Check for broken CMap
         if: github.event_name == 'pull_request'
         run: |
-          NEEDLE=$(grep TEST_SUBSTRING= main_${{ matrix.language }}.tex cut -f2 -d=)
+          NEEDLE="$(grep TEST_SUBSTRING= main_${{ matrix.language }}.tex cut -f2 -d=)"
+          if [[ -z "$NEEDLE" ]]; then
+            echo "No TEST_SUBSTRING found in main_${{ matrix.language }}.tex."
+            exit 1
+          fi
           pdftotext main_${{ matrix.language }}.pdf - | tr '\n' ' ' > main_${{ matrix.language }}.txt
           if grep -iq "$NEEDLE" main_${{ matrix.language }}.txt
           then

--- a/.github/workflows/build-and-publish-rule-book.yaml
+++ b/.github/workflows/build-and-publish-rule-book.yaml
@@ -10,7 +10,7 @@ on:
 env:
   PO4A_VERSION: "0.73"
   PO4A_GH_URL: https://github.com/mquinson/po4a/releases/download
-  GHOSTSCRIPT_URL: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs10030/gs_10.03.0_amd64_snap.tgz
+  GHOSTSCRIPT_URL: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs10040/gs_10.04.0_amd64_snap.tgz
   ARTIFACT_RETENTION_DAYS: 1
 
 jobs:
@@ -85,8 +85,8 @@ jobs:
           path: main_${{ matrix.language }}.pdf
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
 
-      - name: Install pdfinfo
-        if: ${{ matrix.language == 'en' }}
+      - name: Install poppler
+        if: github.event_name == 'pull_request'
         run: sudo apt-get update && sudo apt-get install -y poppler-utils
 
       - name: Check number of pages
@@ -95,6 +95,19 @@ jobs:
         run: |
           NUM_OF_PAGES=$(pdfinfo main_${{ matrix.language }}.pdf | awk '/^Pages:/ {print $2}')
           echo "NUM_OF_PAGES=${NUM_OF_PAGES}" >> "$GITHUB_OUTPUT"
+
+      - name: Check for broken CMap
+        if: github.event_name == 'pull_request'
+        run: |
+          QUOTE=$(grep -A1 heegusquote main_en.tex | tail -1 | grep -o "{.*}" | tail -c +2 | head -c -2)
+          pdftotext main_${{ matrix.language }}.pdf
+          if grep -iq $QUOTE main_${{ matrix.language }}.txt
+          then
+            echo "All good"
+          else
+            echo "The CMap in main_${{ matrix.language }}.pdf file is broken. See the output of 'Optimize PDF' step above."
+            exit 1
+          fi
 
       - name: Move file
         run: |
@@ -140,7 +153,7 @@ jobs:
           echo "NUM_OF_PRINTABLE_PAGES=${NUM_OF_PAGES}" >> "$GITHUB_OUTPUT"
 
       - name: Check if printable page number matches
-        if: ${{ matrix.language == 'en' }}
+        if: ${{ matrix.language == 'en' && github.event_name == 'pull_request' }}
         run: |
           PAGES_DIGITAL="${{ steps.check_pages.outputs.num_of_pages }}"
           PAGES_PRINTABLE="${{ steps.check_printable_pages.outputs.num_of_printable_pages }}"
@@ -196,9 +209,8 @@ jobs:
         language: ["pl", "es", "fr", "ru", "ua", "de", "cs", "he"]
 
     steps:
-      - name: Install pdfinfo
+      - name: Install poppler
         run: sudo apt-get update && sudo apt-get install -y poppler-utils
-
 
       - name: Download PDFs
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-and-publish-rule-book.yaml
+++ b/.github/workflows/build-and-publish-rule-book.yaml
@@ -10,7 +10,7 @@ on:
 env:
   PO4A_VERSION: "0.73"
   PO4A_GH_URL: https://github.com/mquinson/po4a/releases/download
-  GHOSTSCRIPT_URL: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs10040/gs_10.04.0_amd64_snap.tgz
+  GHOSTSCRIPT_URL: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs10030/gs_10.03.0_amd64_snap.tgz
   ARTIFACT_RETENTION_DAYS: 1
 
 jobs:

--- a/.github/workflows/build-and-publish-rule-book.yaml
+++ b/.github/workflows/build-and-publish-rule-book.yaml
@@ -99,9 +99,9 @@ jobs:
       - name: Check for broken CMap
         if: github.event_name == 'pull_request'
         run: |
-          QUOTE=$(grep -A1 heegusquote main_en.tex | tail -1 | grep -o "{.*}" | tail -c +2 | head -c -2)
+          QUOTE=$(grep -A1 heegusquote main_${{ matrix.language }}.tex | tail -1 | grep -o "{.*}" | tail -c +2 | head -c -2)
           pdftotext main_${{ matrix.language }}.pdf
-          if grep -iq $QUOTE main_${{ matrix.language }}.txt
+          if grep -iq "$QUOTE" main_${{ matrix.language }}.txt
           then
             echo "All good"
           else

--- a/.github/workflows/build-and-publish-rule-book.yaml
+++ b/.github/workflows/build-and-publish-rule-book.yaml
@@ -99,7 +99,7 @@ jobs:
       - name: Check for broken CMap
         if: github.event_name == 'pull_request'
         run: |
-          NEEDLE="$(grep TEST_SUBSTRING= main_${{ matrix.language }}.tex cut -f2 -d=)"
+          NEEDLE="$(grep TEST_SUBSTRING= main_${{ matrix.language }}.tex | cut -f2 -d=)"
           if [[ -z "$NEEDLE" ]]; then
             echo "No TEST_SUBSTRING found in main_${{ matrix.language }}.tex."
             exit 1

--- a/.github/workflows/build-and-publish-rule-book.yaml
+++ b/.github/workflows/build-and-publish-rule-book.yaml
@@ -99,8 +99,8 @@ jobs:
       - name: Check for broken CMap
         if: github.event_name == 'pull_request'
         run: |
-          QUOTE=$(grep -A1 heegusquote main_${{ matrix.language }}.tex | tail -1 | grep -o "{.*}" | tail -c +2 | head -c -2)
-          pdftotext main_${{ matrix.language }}.pdf
+          QUOTE=$(grep "intro" main_${{ matrix.language }}.tex -A2 | tail -1 | awk '{$1=$1};1')
+          pdftotext main_$LANG.pdf - | tr '\n' ' ' > main_${{ matrix.language }}.txt
           if grep -iq "$QUOTE" main_${{ matrix.language }}.txt
           then
             echo "All good"

--- a/.github/workflows/build-and-publish-rule-book.yaml
+++ b/.github/workflows/build-and-publish-rule-book.yaml
@@ -99,9 +99,9 @@ jobs:
       - name: Check for broken CMap
         if: github.event_name == 'pull_request'
         run: |
-          QUOTE=$(grep "intro" main_${{ matrix.language }}.tex -A2 | tail -1 | awk '{$1=$1};1')
+          NEEDLE=$(grep TEST_SUBSTRING= main_${{ matrix.language }}.tex cut -f2 -d=)
           pdftotext main_${{ matrix.language }}.pdf - | tr '\n' ' ' > main_${{ matrix.language }}.txt
-          if grep -iq "$QUOTE" main_${{ matrix.language }}.txt
+          if grep -iq "$NEEDLE" main_${{ matrix.language }}.txt
           then
             echo "All good"
           else

--- a/.github/workflows/build-and-publish-rule-book.yaml
+++ b/.github/workflows/build-and-publish-rule-book.yaml
@@ -100,7 +100,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           QUOTE=$(grep "intro" main_${{ matrix.language }}.tex -A2 | tail -1 | awk '{$1=$1};1')
-          pdftotext main_$LANG.pdf - | tr '\n' ' ' > main_${{ matrix.language }}.txt
+          pdftotext main_${{ matrix.language }}.pdf - | tr '\n' ' ' > main_${{ matrix.language }}.txt
           if grep -iq "$QUOTE" main_${{ matrix.language }}.txt
           then
             echo "All good"

--- a/main_cs.tex
+++ b/main_cs.tex
@@ -51,3 +51,5 @@
 \newcommand{\notefont}[0]{\liberation\selectfont}
 
 \input{metadata.tex}
+
+% TEST_SUBSTRING=zanechat zpětnou vazbu

--- a/main_de.tex
+++ b/main_de.tex
@@ -30,3 +30,5 @@
 \title{\includegraphics[width=6cm]{\images/title.png}\\Neufassung}
 
 \input{metadata.tex}
+
+% TEST_SUBSTRING=Feedback hinterlassen möchtest

--- a/main_en.tex
+++ b/main_en.tex
@@ -30,3 +30,5 @@
 \title{\includegraphics[width=6cm]{\images/title.png}\\The Rewrite}
 
 \input{metadata.tex}
+
+% TEST_SUBSTRING=This is a community-driven

--- a/main_es.tex
+++ b/main_es.tex
@@ -39,3 +39,5 @@
 \title{\includegraphics[width=6cm]{\images/title.png}\\Reescritura}
 
 \input{metadata.tex}
+
+% TEST_SUBSTRING=porque me apasiona aprender

--- a/main_fr.tex
+++ b/main_fr.tex
@@ -32,3 +32,5 @@
 \title{\includegraphics[width=6cm]{\images/title.png}\\Révision}
 
 \input{metadata.tex}
+
+% TEST_SUBSTRING=Vous êtes tous invités

--- a/main_he.tex
+++ b/main_he.tex
@@ -75,3 +75,5 @@
 
 
 \input{metadata.tex}
+
+% TEST_SUBSTRING=לשנות ולתקן שגיא

--- a/main_pl.tex
+++ b/main_pl.tex
@@ -30,3 +30,5 @@
 \title{\includegraphics[width=6cm]{\images/title.png}\\Przepisanie}
 
 \input{metadata.tex}
+
+% TEST_SUBSTRING=Robię to z zamiłowania

--- a/main_ru.tex
+++ b/main_ru.tex
@@ -44,3 +44,5 @@
 \newcommand{\notefont}[0]{}
 
 \input{metadata.tex}
+
+% TEST_SUBSTRING=Эта книга поддерживается

--- a/main_ua.tex
+++ b/main_ua.tex
@@ -43,3 +43,5 @@
 \newcommand{\notefont}[0]{}
 
 \input{metadata.tex}
+
+% TEST_SUBSTRING=Вітаються будь-які зміни


### PR DESCRIPTION
This is to get quick feedback if Ghostscript breaks the file's CMap again.

With Ghostscript 10.04 all the files built with LuaTeX are broken, in which case the test should fail.