### PR TITLE
[HE] translate a missed line in main_he.tex

### DIFF
--- a/main_he.tex
+++ b/main_he.tex
@@ -54,7 +54,7 @@
 \toggletrue{textright2left}
 
 \newcommand{\versionlabel}{גרסא}
-\newcommand{\versionwarning}{This is an unreleased version built on GitHub from commit}
+\newcommand{\versionwarning}{זוהי גרסה שטרם שוחררה שנבנתה ב-\textenglish{GitHub} מהקומיט}
 
 \newcommand{\intro}{
 זהו פרוייקט קהילתי מבוסס \href{https://github.com/Heegu-sama/Homm3BG}{גיט}.


### PR DESCRIPTION
I don't see that line in the file that were created on my laptop

![he-02](https://github.com/user-attachments/assets/af5e40f0-6eab-4deb-92da-52bf48299d78)
