### PR TITLE
Make star history chart adaptive

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,13 @@ Their respective XCF files reside in [`assets/gimp-files`](https://github.com/He
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Heegu-sama/Homm3BG&type=Date&branch=master)](https://star-history.com/#Heegu-sama/Homm3BG&Date)
+<a href="https://star-history.com/#Heegu-sama/Homm3BG&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Heegu-sama/Homm3BG&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Heegu-sama/Homm3BG&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Heegu-sama/Homm3BG&type=Date" />
+  </picture>
+</a>
 
 ## 🛡️ Other Community Projects
 


### PR DESCRIPTION
Currently, it's always white, with this change dark theme will look like this:

![image](https://github.com/user-attachments/assets/7b8dd52d-a74f-4fbd-b6c0-168fc8444554)
