### PR TITLE
more clearly wording on trading page

### DIFF
--- a/sections/trading.tex
+++ b/sections/trading.tex
@@ -8,14 +8,15 @@
 The \pagelink{Trading Post}{Trading Post Field} and other effects allow you to either:
 \begin{itemize}
   \item \pagetarget{Trading}{trade}\index{Trading} multiple Resources with the game in accordance to the \hyperlink{Trade Table}{table at the back cover},
-  \item \textbf{remove a card} from your hand at the trading post to gain 1 \svg{gold},
+  \item \textbf{remove exactly one card} from your hand at the trading post to gain 1 \svg{gold},
     \note{5}{Specialty, Statistic, Starting Ability and Magic Arrows \textbf{cannot be removed} in the Trading Post.}\par
   \item or buy a \pagelink{War Machines}{War Machine}, if you have the Rampart expansion.
 \end{itemize}
 In \textbf{Alliance} and \textbf{Cooperative} Scenarios, players are allowed to trade Resources and cards following these rules:
 \begin{itemize}
   \item In Alliance Scenarios, allies may trade Resources freely at any time on their Turns except during Combat.
-  \item In Cooperative Scenarios, Resources may be given to other players when Visiting a Trading Post.
+  \columnbreak
+  \item In Cooperative Scenarios, Resources may be given to other players when Visiting a Trading Post. This works \textbf{in addition} to the regular effect of the Trading Post during a single Visit. 
   \item In both Scenario types, allies may trade \textbf{Spell} and \textbf{Artifact} cards in any mix if they have heroes on adjacent Fields.
     Only \textbf{cards from their hands} may be traded and you must give and receive an equal amount of cards.
 \end{itemize}


### PR DESCRIPTION
Hey together, 

during german translation i found a few parts in the rewrite, where i think it could be more clear. I will create PRs for these parts in the next weeks and show you my suggestions. I will start with trading page, where i have **2 Suggestions** (red marked) and **1 question** (blue marked).

Here the page. See some notes below:
![image](https://github.com/user-attachments/assets/b823e63a-f8b3-48ba-b39e-c4d994011225)

suggestion 1): 
To prevent, that removing a card could be missunderstood as a rate (one gold per card). This questions comes up several times on discord. Clarification from alex: 
![image](https://github.com/user-attachments/assets/b2d8443f-95c2-4d77-b40c-66ebb405ea5e)
[https://discord.com/channels/740870068178649108/1211591995328299038/1268478582557249536](url)

suggestions 2): 
clarification from alex: [(https://discord.com/channels/740870068178649108/1211591995328299038/1317086052107817002)](url). I know, that there is a small risk, because he wrote "he ask kamil", but there are many evidences, that it is addional. Because of that i suggest to change the wording and if we get another clarification we make it undone.


