### PR TITLE
Specialties are not spells

### DIFF
--- a/sections/deckbuilding.tex
+++ b/sections/deckbuilding.tex
@@ -244,8 +244,9 @@ By default there's no difference, but certain game effects can refer to specific
 
 Hero Specialty Cards\index{Specialty Card} are gained from \pagelink{Level}{Level ups}.
 Each Main Hero has a unique set of Specialty Cards.
-While many of these Cards have effects which resemble Spell Cards and even make use of \svg{empower} and Schools of Magic, Specialty Cards are their \textbf{own unique category of cards}.
-For example, the limit of 1 Spell per Combat Round doesn't apply to Specialty Cards.
+While some of these Cards have effects which resemble Spell Cards and even make use of \svg{empower}, Specialty Cards are their \textbf{own unique category of cards}.
+For example, the limit of 1 Spell per Combat Round doesn't apply to Specialty Cards, and Schools of Magic don't apply to them.
+\textbf{Ignore} the School of Magic symbol on the Specialty Cards, if it's present.
 
 {
   \medskip


### PR DESCRIPTION
I wonder how this crept in here. Probably I made a wrong assumption before based on the symbol being present.

![en-21](https://github.com/user-attachments/assets/df20c069-8cd8-47d0-8a5e-2ebbe3df8d6e)
