### PR TITLE
[WIP] Add bleed support for printable mode

### DIFF
--- a/metadata.tex
+++ b/metadata.tex
@@ -1,14 +1,50 @@
-% Set page size and margins
-\usepackage[
-  a4paper,
-  top=2cm,
-  bottom=2.3cm,
-  left=2cm,
-  right=2cm,
-  marginparwidth=1.75cm,
-  footskip=1.35cm,
-]{geometry}
+\usepackage{etoolbox}
+\newtoggle{printable}
+\newtoggle{noartbackground}
+\newtoggle{githubbuild}
 
+
+% Computes trimmed size and bleed margins (for print) or plain A4 (for digital)
+\newlength\trimW \setlength\trimW{210mm}
+\newlength\trimH \setlength\trimH{297mm}
+\newlength\bleedTop    \setlength\bleedTop{3mm}
+\newlength\bleedBottom \setlength\bleedBottom{3mm}
+\newlength\bleedLeft   \setlength\bleedLeft{3mm}
+\newlength\bleedRight  \setlength\bleedRight{3mm}
+
+\edef\GEOpw{\the\dimexpr\trimW+\bleedLeft+\bleedRight\relax}
+\edef\GEOph{\the\dimexpr\trimH+\bleedTop+\bleedBottom\relax}
+\edef\GEOlw{\the\trimW}
+\edef\GEOlh{\the\trimH}
+\edef\GEOhx{\the\bleedLeft}
+\edef\GEOvy{\the\bleedTop}
+
+\iftoggle{printable}{%
+  % Printable build with bleed
+  \usepackage[
+    layoutwidth=\GEOlw, layoutheight=\GEOlh,
+    layouthoffset=\bleedLeft, layoutvoffset=\bleedTop,
+    paperwidth=\GEOpw, paperheight=\GEOph,
+    twoside,
+    top=2cm,
+    bottom=2.3cm,
+    left=2.5cm,
+    right=1.5cm,
+    marginparwidth=1.75cm,
+    footskip=1.35cm,
+  ]{geometry}%
+}{%
+  % Digital build (no bleed)
+  \usepackage[
+    a4paper,
+    top=2cm,
+    bottom=2.3cm,
+    left=2cm,
+    right=2cm,
+    marginparwidth=1.75cm,
+    footskip=1.35cm
+  ]{geometry}%
+}
 % Useful packages
 \usepackage[export]{adjustbox}
 \usepackage{amsmath}
@@ -16,7 +52,6 @@
 \usepackage{caption}
 \usepackage[strict]{changepage}
 \usepackage{enumitem}
-\usepackage{etoolbox}
 \usepackage{float}
 \usepackage{fullwidth}
 \usepackage{graphicx, trimclip}
@@ -75,9 +110,6 @@
 \usetikzlibrary{shadows, shadows.blur, calc, backgrounds}
 
 \setlength{\columnsep}{1cm}
-\newtoggle{printable}
-\newtoggle{noartbackground}
-\newtoggle{githubbuild}
 
 \setlist[itemize,2]{leftmargin=15pt, label=$\triangleright$}
 
@@ -521,18 +553,6 @@
 \makeindex[columns=3, title=,]
 
 \begin{document}
-
-\iftoggle{printable}{
-  \newgeometry{
-    twoside,
-    top=2cm,
-    bottom=2.3cm,
-    left=2.5cm,
-    right=1.5cm,
-    marginparwidth=1.75cm,
-    footskip=1.35cm,
-  }
-}{}
 
 \input{structure.tex}
 


### PR DESCRIPTION
Add support for bleed in printable mode. Default bleed size is set to 3mm (standard). In this mode, the actual page size will grow from 210 x 297 mm to 216 x 303 mm. Setting the bleed to zero is equivalent to the printable mode we had since the begining.

<p align="center">
<img src="https://github.com/user-attachments/assets/d8279741-2b88-4e61-a4ea-15322f40f418" width="300">
</p>



The only hiccup is the bottom layout :
(digital)
<img width="1587" height="125" alt="image" src="https://github.com/user-attachments/assets/bbc8ce20-efa7-4677-8788-d7e3a7b08fc7" />
(bleed + printable)
<img width="1638" height="131" alt="image" src="https://github.com/user-attachments/assets/87d8e195-76d6-4197-a618-66f2e3225565" />

The bleed lowers the bottom layout and it does not match the original. But the digital and printable bottom are different to begin with (smaller in width, that is why the printable image is distorted). 


Remaining things to do:
- [ ] use the original bottom layout ? and shift for odd/even pages and expand around 35px (for 300 DPI) vertically so that it is more akin to the original. This would be *harcoded* for 3mm bleed at 300 DPI.
- [ ] Recheck the *-p|--printable* console option, did not work for me...
- [x] The cover images and other backgrounds relying on *\paperwidth* are a little bit translated by the bleed, but I don't think it's worth the effort. It's hard to see the difference.

 
