### PR TITLE
Fix pdf2image.sh compatibility with Bash 3.2 on macOS

### DIFF
--- a/tools/pdf2image.sh
+++ b/tools/pdf2image.sh
@@ -106,7 +106,10 @@ if [[ ! -f "$source_pdf" ]]; then
 fi
 
 # Process each page or page range
-readarray -t pages < <(parse_pages "$range")
+pages=()
+while IFS= read -r line; do
+  pages+=("$line")
+done < <(parse_pages "$range")
 
 for page in "${pages[@]}"; do
   echo "Processing page $page from $source_pdf..."


### PR DESCRIPTION
readarray doesn't exist in the default bash in MacOS. the default is 3.2
so.. If it is possible to change for something older, but workable - it would be nice

if not - I'll just use this as a hotfix in my local git 