### PR TITLE
Convert expansion colors to CMYK

### DIFF
--- a/metadata.tex
+++ b/metadata.tex
@@ -153,7 +153,7 @@
 \definecolor{fortress}     {cmyk}{0.20, 0.00, 0.55, 0.61}  % darkolivegreen
 \definecolor{inferno}      {cmyk}{0.00, 0.80, 0.80, 0.30}  % firebrick
 \definecolor{stronghold}   {cmyk}{0.00, 0.25, 0.51, 0.39}  % tan
-\definecolor{conflux}      {cmyk}{0.00, 0.54, 0.00, 0.07}  % orchid
+\definecolor{conflux}      {cmyk}{0.00, 0.54, 0.00, 0.23}  % orchid
 \definecolor{cove}         {cmyk}{0.95, 0.00, 0.00, 0.17}  % lightseagreen
 \definecolor{battlefield}  {cmyk}{0.00, 0.00, 0.00, 0.70}  % dark gray
 \definecolor{navalbattles} {cmyk}{0.89, 0.39, 0.00, 0.10}  % dark deep blue


### PR DESCRIPTION
This change does the following:
 - converts expansion colors from RGB color space to CMYK
 - significantly changes colors for naval battles and cove, as those differed visibly after conversion due to significant blue component
 - slightly adjusts tower, fortress, and stronghold colors to make colors dissimilar among each other
 - made stretchgoals2 color "rich" black to differentiate it from gray battlefield
 - the rest of the expansions remained similar to their original RBG counterparts
 
 Preview of changes (both renders are after CMYK conversion):

<img width="2482" height="1754" alt="en-06" src="https://github.com/user-attachments/assets/02f6f15f-206e-4f2a-956a-37d1f21c5111" />
<img width="2482" height="1754" alt="en-08" src="https://github.com/user-attachments/assets/c1deb801-fdc4-4f18-8630-74ccd76bc4bf" />
<img width="2482" height="1754" alt="en-09" src="https://github.com/user-attachments/assets/368bd6ee-f6a6-4bf9-ae3a-f1dd34198680" />
<img width="2482" height="1754" alt="en-10" src="https://github.com/user-attachments/assets/072d9cf1-1565-4669-8a91-47f6376e4359" />
<img width="2482" height="1754" alt="en-11" src="https://github.com/user-attachments/assets/61a8299e-72a3-4e7d-b5c5-d890b83ee7f8" />
<img width="2482" height="1754" alt="en-14" src="https://github.com/user-attachments/assets/5c136d15-32db-4454-9f16-a450f2c60ae4" />
<img width="2482" height="1754" alt="en-24" src="https://github.com/user-attachments/assets/8a175c2a-dcad-4ef3-99ea-06355932df2b" />
<img width="2482" height="1754" alt="en-27" src="https://github.com/user-attachments/assets/5aa03e6d-74ee-4ff4-9f11-3b268d3c386d" />
<img width="2482" height="1754" alt="en-28" src="https://github.com/user-attachments/assets/efe7c56b-1116-488c-a0f9-cecdbeb721d5" />
<img width="2482" height="1754" alt="en-34" src="https://github.com/user-attachments/assets/a6a9f916-482a-44ae-974a-c38c26ed2b9a" />
<img width="2482" height="1754" alt="en-35" src="https://github.com/user-attachments/assets/01af014c-6930-40b5-aff1-4243fe7f3de1" />
<img width="2482" height="1754" alt="en-38" src="https://github.com/user-attachments/assets/bd48c6d0-c71d-4e5d-965e-2aff78d8d818" />
<img width="2482" height="1754" alt="en-60" src="https://github.com/user-attachments/assets/8ce17159-3164-43a4-8d22-ee4d7b24c70f" />
<img width="2482" height="1754" alt="en-61" src="https://github.com/user-attachments/assets/f9c60ec1-0dc6-4523-b8bb-731fe7a904e9" />
<img width="2482" height="1754" alt="en-72" src="https://github.com/user-attachments/assets/96b7cea3-c3b2-4345-969a-0d19725d6e19" />
<img width="2482" height="1754" alt="en-73" src="https://github.com/user-attachments/assets/342c3fb6-d99b-4bb0-941c-2de2d3424ea2" />
<img width="2482" height="1754" alt="en-74" src="https://github.com/user-attachments/assets/18646842-3647-4f0f-87fe-d87443eb29ab" />
<img width="2482" height="1754" alt="en-75" src="https://github.com/user-attachments/assets/5177f776-58d5-47e0-8490-be9e30de5123" />
<img width="2482" height="1754" alt="en-86" src="https://github.com/user-attachments/assets/a58dc468-2148-4317-bd4e-424a92ca1536" />
<img width="2482" height="1754" alt="en-89" src="https://github.com/user-attachments/assets/7ff6e7b4-13aa-4772-b5ba-cabb5a0ec12a" />
<img width="2482" height="1754" alt="en-90" src="https://github.com/user-attachments/assets/078b2ebb-4f2c-42d0-9b6d-25279b61f6ca" />
<img width="2482" height="1754" alt="en-91" src="https://github.com/user-attachments/assets/c8f76b9f-6c18-40c3-9e14-69eac8345cf8" />
<img width="2482" height="1754" alt="en-92" src="https://github.com/user-attachments/assets/30ecbea1-0714-4807-bf5d-ef612d622e29" />
