### PR TITLE
deemphasize units in tokens

### DIFF
--- a/sections/card_effect_keywords.tex
+++ b/sections/card_effect_keywords.tex
@@ -295,7 +295,7 @@ These Tokens are typically placed on other units to modify their statistics.
     A unit can have only one Corrosion Token at a time.
     If a unit would gain a second Corrosion Token, discard one of them.
     Unless removed by Spells or other effects, a Corrosion Token remains on the unit until the end of Combat.
-    \textit{For example, this Token is given to enemy units by \wikilink{units/behemoths}{Behemoths}'s special ability}.
+    \textit{For example, this Token is given to enemy units by the \wikilink{units/behemoths}{Behemoths} unit's ability.}
   \end{expansion}
 \end{multicols}
 

--- a/sections/card_effect_keywords.tex
+++ b/sections/card_effect_keywords.tex
@@ -276,7 +276,7 @@ These Tokens are typically placed on other units to modify their statistics.
     Units with such a Token gain an additional 1~\svg{attack} or 2~\svg{attack}, as indicated by the Token's side.
     Each unit can have only one Attack Token at a time.
     If a unit would gain a second one, the player controlling it chooses which one to keep.
-    \textit{For example, this Token can be given to units by \wikilink{units/ogres}{Ogres} unit's ability.}
+    \textit{For example, this Token can be given to units by the \wikilink{units/ogres}{Ogres} unit's ability.}
   \end{expansion}
 
   \vspace*{1em}

--- a/sections/card_effect_keywords.tex
+++ b/sections/card_effect_keywords.tex
@@ -252,7 +252,7 @@ These Tokens are typically placed on other units to modify their statistics.
     A unit with this Token suffers $-1$~\svg{attack} or $-2$~\svg{attack}, as indicated by the Token's side.
     Each unit can have only one Weakness Token at a time.
     If a unit would gain a second one, the player controlling it chooses which one to keep.
-    \textit{For example, this Token can be given to units by \wikilink{units/sorceresses}{Sorceresses} unit's ability.}
+    \textit{For example, this Token can be given to units by the \wikilink{units/sorceresses}{Sorceresses} unit's ability.}
     \begin{center}
       \vspace*{2.5em}
       {\transparent{0.2}\includegraphics[width=0.9\linewidth]{\art/weakness.png}}

--- a/sections/card_effect_keywords.tex
+++ b/sections/card_effect_keywords.tex
@@ -232,7 +232,7 @@ Use the corresponding Tokens to mark these spaces.
 
 
 \clearpage
-\pagetarget{unit keywords}{\subheader{Unit Ability keywords}}
+\pagetarget{unit keywords}{\subheader{Tokens on Units}}
 
 The following components and keywords are used by certain unit abilities.
 These Tokens are typically placed on other units to modify their statistics.
@@ -248,11 +248,11 @@ These Tokens are typically placed on other units to modify their statistics.
       \imagecaption{Weakness Token}\\
       \vspace{1em}
     \end{wrapfigure}
-    \textbf{\wikilink{units/sorceresses/\#few}{``Few'' Sorceresses}} unit from the Cove Faction can use their \svg{unit_alternative} ability to place a Weakness Token on any unit.  % enemy unit?
-    A~\wikilink{units/sorceresses/\#pack}{\textbf{``Pack'' of Sorceresses}} places this Token automatically on a unit attacked by them due to their \svg{unit_attack} ability.
+    When an effect places a Weakness Token on a unit, it specifies which side to use: $-1$ or $-2$.
     A unit with this Token suffers $-1$~\svg{attack} or $-2$~\svg{attack}, as indicated by the Token's side.
     Each unit can have only one Weakness Token at a time.
     If a unit would gain a second one, the player controlling it chooses which one to keep.
+    \textit{For example, this Token can be given to units by \wikilink{units/sorceresses}{Sorceresses} unit's ability.}
     \begin{center}
       \vspace*{2.5em}
       {\transparent{0.2}\includegraphics[width=0.9\linewidth]{\art/weakness.png}}
@@ -272,10 +272,11 @@ These Tokens are typically placed on other units to modify their statistics.
       \imagecaption{Attack Token}\\
       \vspace{1em}
     \end{wrapfigure}
-    The \textbf{\wikilink{units/ogres}{Ogres}} unit from the Stronghold Faction can use their \svg{unit_alternative} ability to place Attack Tokens on other allied unit cards.
+    When an effect places an Attack Token on a unit, it specifies which side to use: $1$ or $2$.
     Units with such a Token gain an additional 1~\svg{attack} or 2~\svg{attack}, as indicated by the Token's side.
     Each unit can have only one Attack Token at a time.
     If a unit would gain a second one, the player controlling it chooses which one to keep.
+    \textit{For example, this Token can be given to units by \wikilink{units/ogres}{Ogres} unit's ability.}
   \end{expansion}
 
   \vspace*{1em}
@@ -290,11 +291,11 @@ These Tokens are typically placed on other units to modify their statistics.
       \imagecaption{Corrosion Token}\\
       \vspace{1em}
     \end{wrapfigure}
-    The \textbf{\wikilink{units/behemoths}{Behemoths}} unit from the Stronghold Faction can use their \svg{unit_attack} ability to place a Corrosion Token on a unit attacked by them.
-    It reduces the enemy's unit \svg{defense} by 1 to a minimum of 0.
+    The Corrosion Token reduces the unit's \svg{defense} by 1 to a minimum of 0.
     A unit can have only one Corrosion Token at a time.
-    If a unit would gain a second Token, discard one of them.
+    If a unit would gain a second Corrosion Token, discard one of them.
     Unless removed by Spells or other effects, a Corrosion Token remains on the unit until the end of Combat.
+    \textit{For example, this Token is given to enemy units by \wikilink{units/behemoths}{Behemoths}'s special ability}.
   \end{expansion}
 \end{multicols}
 

--- a/translations/card_effect_keywords.tex/card_effect_keywords.tex.pot
+++ b/translations/card_effect_keywords.tex/card_effect_keywords.tex.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-03-30 23:32+0100\n"
+"POT-Creation-Date: 2026-04-09 19:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -415,7 +415,7 @@ msgstr ""
 
 #. type: Plain text
 #: sections/card_effect_keywords.tex:236
-msgid "\\pagetarget{unit keywords}{\\subheader{Unit Ability keywords}}"
+msgid "\\pagetarget{unit keywords}{\\subheader{Tokens on Units}}"
 msgstr ""
 
 #. type: Plain text
@@ -441,11 +441,11 @@ msgid ""
 "      \\imagecaption{Weakness Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    \\textbf{\\wikilink{units/sorceresses/\\#few}{``Few'' Sorceresses}} unit from the Cove Faction can use their \\svg{unit_alternative} ability to place a Weakness Token on any unit.  % enemy unit?\n"
-"    A~\\wikilink{units/sorceresses/\\#pack}{\\textbf{``Pack'' of Sorceresses}} places this Token automatically on a unit attacked by them due to their \\svg{unit_attack} ability.\n"
+"    When an effect places a Weakness Token on a unit, it specifies which side to use: $-1$ or $-2$.\n"
 "    A unit with this Token suffers $-1$~\\svg{attack} or $-2$~\\svg{attack}, as indicated by the Token's side.\n"
 "    Each unit can have only one Weakness Token at a time.\n"
 "    If a unit would gain a second one, the player controlling it chooses which one to keep.\n"
+"    \\textit{For example, this Token can be given to units by the \\wikilink{units/sorceresses}{Sorceresses} unit's ability.}\n"
 "    \\begin{center}\n"
 "      \\vspace*{2.5em}\n"
 "      {\\transparent{0.2}\\includegraphics[width=0.9\\linewidth]{\\art/weakness.png}}\n"
@@ -457,7 +457,7 @@ msgid ""
 msgstr ""
 
 #. type: multicols
-#: sections/card_effect_keywords.tex:280
+#: sections/card_effect_keywords.tex:281
 #, no-wrap
 msgid ""
 "  \\begin{expansion}{stronghold,stretchgoals2}\n"
@@ -471,16 +471,17 @@ msgid ""
 "      \\imagecaption{Attack Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    The \\textbf{\\wikilink{units/ogres}{Ogres}} unit from the Stronghold Faction can use their \\svg{unit_alternative} ability to place Attack Tokens on other allied unit cards.\n"
+"    When an effect places an Attack Token on a unit, it specifies which side to use: $1$ or $2$.\n"
 "    Units with such a Token gain an additional 1~\\svg{attack} or 2~\\svg{attack}, as indicated by the Token's side.\n"
 "    Each unit can have only one Attack Token at a time.\n"
 "    If a unit would gain a second one, the player controlling it chooses which one to keep.\n"
+"    \\textit{For example, this Token can be given to units by the \\wikilink{units/ogres}{Ogres} unit's ability.}\n"
 "  \\end{expansion}\n"
 "\n"
 msgstr ""
 
 #. type: multicols
-#: sections/card_effect_keywords.tex:299
+#: sections/card_effect_keywords.tex:300
 #, no-wrap
 msgid ""
 "  \\vspace*{1em}\n"
@@ -495,26 +496,26 @@ msgid ""
 "      \\imagecaption{Corrosion Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    The \\textbf{\\wikilink{units/behemoths}{Behemoths}} unit from the Stronghold Faction can use their \\svg{unit_attack} ability to place a Corrosion Token on a unit attacked by them.\n"
-"    It reduces the enemy's unit \\svg{defense} by 1 to a minimum of 0.\n"
+"    The Corrosion Token reduces the unit's \\svg{defense} by 1 to a minimum of 0.\n"
 "    A unit can have only one Corrosion Token at a time.\n"
-"    If a unit would gain a second Token, discard one of them.\n"
+"    If a unit would gain a second Corrosion Token, discard one of them.\n"
 "    Unless removed by Spells or other effects, a Corrosion Token remains on the unit until the end of Combat.\n"
+"    \\textit{For example, this Token is given to enemy units by the \\wikilink{units/behemoths}{Behemoths} unit's ability.}\n"
 "  \\end{expansion}"
 msgstr ""
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:307
+#: sections/card_effect_keywords.tex:308
 msgid "\\pagetarget{wiki}{\\subheader{Fan-Made Wiki}}"
 msgstr ""
 
 #. type: wrapfigure
-#: sections/card_effect_keywords.tex:307
+#: sections/card_effect_keywords.tex:308
 msgid "{r}{0.2\\textwidth}"
 msgstr ""
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:310
+#: sections/card_effect_keywords.tex:311
 msgid ""
 "Many cards in \\textbf{Heroes of Might and Magic 3: The Board Game} have "
 "ambiguous or misleading wording.  Fortunately, the developers have clarified "
@@ -522,7 +523,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:314
+#: sections/card_effect_keywords.tex:315
 msgid ""
 "The Community maintains a \\textbf{Fan-Made Wiki}: a collection of nearly "
 "all game components with extensive notes to clarify specific rules.  If you "

--- a/translations/card_effect_keywords.tex/cs.po
+++ b/translations/card_effect_keywords.tex/cs.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-03-30 23:32+0100\n"
+"POT-Creation-Date: 2026-04-09 19:11+0100\n"
 "PO-Revision-Date: 2025-11-29 16:03+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -540,7 +540,7 @@ msgstr ""
 #: sections/card_effect_keywords.tex:236
 #, fuzzy
 #| msgid "\\pagetarget{Other Fields}{Other Fields}"
-msgid "\\pagetarget{unit keywords}{\\subheader{Unit Ability keywords}}"
+msgid "\\pagetarget{unit keywords}{\\subheader{Tokens on Units}}"
 msgstr "\\pagetarget{Other Fields}{Ostatní Pole}"
 
 #. type: Plain text
@@ -566,11 +566,11 @@ msgid ""
 "      \\imagecaption{Weakness Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    \\textbf{\\wikilink{units/sorceresses/\\#few}{``Few'' Sorceresses}} unit from the Cove Faction can use their \\svg{unit_alternative} ability to place a Weakness Token on any unit.  % enemy unit?\n"
-"    A~\\wikilink{units/sorceresses/\\#pack}{\\textbf{``Pack'' of Sorceresses}} places this Token automatically on a unit attacked by them due to their \\svg{unit_attack} ability.\n"
+"    When an effect places a Weakness Token on a unit, it specifies which side to use: $-1$ or $-2$.\n"
 "    A unit with this Token suffers $-1$~\\svg{attack} or $-2$~\\svg{attack}, as indicated by the Token's side.\n"
 "    Each unit can have only one Weakness Token at a time.\n"
 "    If a unit would gain a second one, the player controlling it chooses which one to keep.\n"
+"    \\textit{For example, this Token can be given to units by the \\wikilink{units/sorceresses}{Sorceresses} unit's ability.}\n"
 "    \\begin{center}\n"
 "      \\vspace*{2.5em}\n"
 "      {\\transparent{0.2}\\includegraphics[width=0.9\\linewidth]{\\art/weakness.png}}\n"
@@ -582,7 +582,7 @@ msgid ""
 msgstr ""
 
 #. type: multicols
-#: sections/card_effect_keywords.tex:280
+#: sections/card_effect_keywords.tex:281
 #, no-wrap
 msgid ""
 "  \\begin{expansion}{stronghold,stretchgoals2}\n"
@@ -596,16 +596,17 @@ msgid ""
 "      \\imagecaption{Attack Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    The \\textbf{\\wikilink{units/ogres}{Ogres}} unit from the Stronghold Faction can use their \\svg{unit_alternative} ability to place Attack Tokens on other allied unit cards.\n"
+"    When an effect places an Attack Token on a unit, it specifies which side to use: $1$ or $2$.\n"
 "    Units with such a Token gain an additional 1~\\svg{attack} or 2~\\svg{attack}, as indicated by the Token's side.\n"
 "    Each unit can have only one Attack Token at a time.\n"
 "    If a unit would gain a second one, the player controlling it chooses which one to keep.\n"
+"    \\textit{For example, this Token can be given to units by the \\wikilink{units/ogres}{Ogres} unit's ability.}\n"
 "  \\end{expansion}\n"
 "\n"
 msgstr ""
 
 #. type: multicols
-#: sections/card_effect_keywords.tex:299
+#: sections/card_effect_keywords.tex:300
 #, no-wrap
 msgid ""
 "  \\vspace*{1em}\n"
@@ -620,16 +621,16 @@ msgid ""
 "      \\imagecaption{Corrosion Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    The \\textbf{\\wikilink{units/behemoths}{Behemoths}} unit from the Stronghold Faction can use their \\svg{unit_attack} ability to place a Corrosion Token on a unit attacked by them.\n"
-"    It reduces the enemy's unit \\svg{defense} by 1 to a minimum of 0.\n"
+"    The Corrosion Token reduces the unit's \\svg{defense} by 1 to a minimum of 0.\n"
 "    A unit can have only one Corrosion Token at a time.\n"
-"    If a unit would gain a second Token, discard one of them.\n"
+"    If a unit would gain a second Corrosion Token, discard one of them.\n"
 "    Unless removed by Spells or other effects, a Corrosion Token remains on the unit until the end of Combat.\n"
+"    \\textit{For example, this Token is given to enemy units by the \\wikilink{units/behemoths}{Behemoths} unit's ability.}\n"
 "  \\end{expansion}"
 msgstr ""
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:307
+#: sections/card_effect_keywords.tex:308
 #, fuzzy
 #| msgid ""
 #| "{2}\n"
@@ -642,12 +643,12 @@ msgstr ""
 "\n"
 
 #. type: wrapfigure
-#: sections/card_effect_keywords.tex:307
+#: sections/card_effect_keywords.tex:308
 msgid "{r}{0.2\\textwidth}"
 msgstr ""
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:310
+#: sections/card_effect_keywords.tex:311
 msgid ""
 "Many cards in \\textbf{Heroes of Might and Magic 3: The Board Game} have "
 "ambiguous or misleading wording.  Fortunately, the developers have clarified "
@@ -655,7 +656,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:314
+#: sections/card_effect_keywords.tex:315
 msgid ""
 "The Community maintains a \\textbf{Fan-Made Wiki}: a collection of nearly "
 "all game components with extensive notes to clarify specific rules.  If you "

--- a/translations/card_effect_keywords.tex/de.po
+++ b/translations/card_effect_keywords.tex/de.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2026-03-30 23:32+0100\n"
+"POT-Creation-Date: 2026-04-09 19:11+0100\n"
 "PO-Revision-Date: 2026-02-07 15:01+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -733,7 +733,9 @@ msgstr ""
 
 #. type: Plain text
 #: sections/card_effect_keywords.tex:236
-msgid "\\pagetarget{unit keywords}{\\subheader{Unit Ability keywords}}"
+#, fuzzy
+#| msgid "\\pagetarget{unit keywords}{\\subheader{Unit Ability keywords}}"
+msgid "\\pagetarget{unit keywords}{\\subheader{Tokens on Units}}"
 msgstr ""
 "\\pagetarget{unit keywords}{\\subheader{Schlüsselwörter auf Einheitenkarten}}"
 
@@ -788,11 +790,11 @@ msgid ""
 "      \\imagecaption{Weakness Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    \\textbf{\\wikilink{units/sorceresses/\\#few}{``Few'' Sorceresses}} unit from the Cove Faction can use their \\svg{unit_alternative} ability to place a Weakness Token on any unit.  % enemy unit?\n"
-"    A~\\wikilink{units/sorceresses/\\#pack}{\\textbf{``Pack'' of Sorceresses}} places this Token automatically on a unit attacked by them due to their \\svg{unit_attack} ability.\n"
+"    When an effect places a Weakness Token on a unit, it specifies which side to use: $-1$ or $-2$.\n"
 "    A unit with this Token suffers $-1$~\\svg{attack} or $-2$~\\svg{attack}, as indicated by the Token's side.\n"
 "    Each unit can have only one Weakness Token at a time.\n"
 "    If a unit would gain a second one, the player controlling it chooses which one to keep.\n"
+"    \\textit{For example, this Token can be given to units by the \\wikilink{units/sorceresses}{Sorceresses} unit's ability.}\n"
 "    \\begin{center}\n"
 "      \\vspace*{2.5em}\n"
 "      {\\transparent{0.2}\\includegraphics[width=0.9\\linewidth]{\\art/weakness.png}}\n"
@@ -829,7 +831,7 @@ msgstr ""
 "\n"
 
 #. type: multicols
-#: sections/card_effect_keywords.tex:280
+#: sections/card_effect_keywords.tex:281
 #, fuzzy, no-wrap
 #| msgid ""
 #| "  \\begin{expansion}{stronghold,stretchgoals2}\n"
@@ -860,10 +862,11 @@ msgid ""
 "      \\imagecaption{Attack Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    The \\textbf{\\wikilink{units/ogres}{Ogres}} unit from the Stronghold Faction can use their \\svg{unit_alternative} ability to place Attack Tokens on other allied unit cards.\n"
+"    When an effect places an Attack Token on a unit, it specifies which side to use: $1$ or $2$.\n"
 "    Units with such a Token gain an additional 1~\\svg{attack} or 2~\\svg{attack}, as indicated by the Token's side.\n"
 "    Each unit can have only one Attack Token at a time.\n"
 "    If a unit would gain a second one, the player controlling it chooses which one to keep.\n"
+"    \\textit{For example, this Token can be given to units by the \\wikilink{units/ogres}{Ogres} unit's ability.}\n"
 "  \\end{expansion}\n"
 "\n"
 msgstr ""
@@ -886,7 +889,7 @@ msgstr ""
 "\n"
 
 #. type: multicols
-#: sections/card_effect_keywords.tex:299
+#: sections/card_effect_keywords.tex:300
 #, fuzzy, no-wrap
 #| msgid ""
 #| "  \\vspace*{1em}\n"
@@ -919,11 +922,11 @@ msgid ""
 "      \\imagecaption{Corrosion Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    The \\textbf{\\wikilink{units/behemoths}{Behemoths}} unit from the Stronghold Faction can use their \\svg{unit_attack} ability to place a Corrosion Token on a unit attacked by them.\n"
-"    It reduces the enemy's unit \\svg{defense} by 1 to a minimum of 0.\n"
+"    The Corrosion Token reduces the unit's \\svg{defense} by 1 to a minimum of 0.\n"
 "    A unit can have only one Corrosion Token at a time.\n"
-"    If a unit would gain a second Token, discard one of them.\n"
+"    If a unit would gain a second Corrosion Token, discard one of them.\n"
 "    Unless removed by Spells or other effects, a Corrosion Token remains on the unit until the end of Combat.\n"
+"    \\textit{For example, this Token is given to enemy units by the \\wikilink{units/behemoths}{Behemoths} unit's ability.}\n"
 "  \\end{expansion}"
 msgstr ""
 " \\vspace*{1em}\n"
@@ -946,17 +949,17 @@ msgstr ""
 "  \\vspace*{1em}  \\end{expansion}"
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:307
+#: sections/card_effect_keywords.tex:308
 msgid "\\pagetarget{wiki}{\\subheader{Fan-Made Wiki}}"
 msgstr "\\pagetarget{wiki}{\\subheader{Fanmade Wiki}}"
 
 #. type: wrapfigure
-#: sections/card_effect_keywords.tex:307
+#: sections/card_effect_keywords.tex:308
 msgid "{r}{0.2\\textwidth}"
 msgstr ""
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:310
+#: sections/card_effect_keywords.tex:311
 msgid ""
 "Many cards in \\textbf{Heroes of Might and Magic 3: The Board Game} have "
 "ambiguous or misleading wording.  Fortunately, the developers have clarified "
@@ -967,7 +970,7 @@ msgstr ""
 "die Entwickler viele Karteneffekte richtig gestellt."
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:314
+#: sections/card_effect_keywords.tex:315
 msgid ""
 "The Community maintains a \\textbf{Fan-Made Wiki}: a collection of nearly "
 "all game components with extensive notes to clarify specific rules.  If you "

--- a/translations/card_effect_keywords.tex/es.po
+++ b/translations/card_effect_keywords.tex/es.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-03-30 23:32+0100\n"
+"POT-Creation-Date: 2026-04-09 19:11+0100\n"
 "PO-Revision-Date: 2025-11-29 16:03+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -529,7 +529,7 @@ msgstr ""
 #: sections/card_effect_keywords.tex:236
 #, fuzzy
 #| msgid "\\pagetarget{Other Fields}{Other Fields}"
-msgid "\\pagetarget{unit keywords}{\\subheader{Unit Ability keywords}}"
+msgid "\\pagetarget{unit keywords}{\\subheader{Tokens on Units}}"
 msgstr "\\pagetarget{Other Fields}{Otras Casillas}"
 
 #. type: Plain text
@@ -555,11 +555,11 @@ msgid ""
 "      \\imagecaption{Weakness Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    \\textbf{\\wikilink{units/sorceresses/\\#few}{``Few'' Sorceresses}} unit from the Cove Faction can use their \\svg{unit_alternative} ability to place a Weakness Token on any unit.  % enemy unit?\n"
-"    A~\\wikilink{units/sorceresses/\\#pack}{\\textbf{``Pack'' of Sorceresses}} places this Token automatically on a unit attacked by them due to their \\svg{unit_attack} ability.\n"
+"    When an effect places a Weakness Token on a unit, it specifies which side to use: $-1$ or $-2$.\n"
 "    A unit with this Token suffers $-1$~\\svg{attack} or $-2$~\\svg{attack}, as indicated by the Token's side.\n"
 "    Each unit can have only one Weakness Token at a time.\n"
 "    If a unit would gain a second one, the player controlling it chooses which one to keep.\n"
+"    \\textit{For example, this Token can be given to units by the \\wikilink{units/sorceresses}{Sorceresses} unit's ability.}\n"
 "    \\begin{center}\n"
 "      \\vspace*{2.5em}\n"
 "      {\\transparent{0.2}\\includegraphics[width=0.9\\linewidth]{\\art/weakness.png}}\n"
@@ -571,7 +571,7 @@ msgid ""
 msgstr ""
 
 #. type: multicols
-#: sections/card_effect_keywords.tex:280
+#: sections/card_effect_keywords.tex:281
 #, no-wrap
 msgid ""
 "  \\begin{expansion}{stronghold,stretchgoals2}\n"
@@ -585,16 +585,17 @@ msgid ""
 "      \\imagecaption{Attack Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    The \\textbf{\\wikilink{units/ogres}{Ogres}} unit from the Stronghold Faction can use their \\svg{unit_alternative} ability to place Attack Tokens on other allied unit cards.\n"
+"    When an effect places an Attack Token on a unit, it specifies which side to use: $1$ or $2$.\n"
 "    Units with such a Token gain an additional 1~\\svg{attack} or 2~\\svg{attack}, as indicated by the Token's side.\n"
 "    Each unit can have only one Attack Token at a time.\n"
 "    If a unit would gain a second one, the player controlling it chooses which one to keep.\n"
+"    \\textit{For example, this Token can be given to units by the \\wikilink{units/ogres}{Ogres} unit's ability.}\n"
 "  \\end{expansion}\n"
 "\n"
 msgstr ""
 
 #. type: multicols
-#: sections/card_effect_keywords.tex:299
+#: sections/card_effect_keywords.tex:300
 #, no-wrap
 msgid ""
 "  \\vspace*{1em}\n"
@@ -609,16 +610,16 @@ msgid ""
 "      \\imagecaption{Corrosion Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    The \\textbf{\\wikilink{units/behemoths}{Behemoths}} unit from the Stronghold Faction can use their \\svg{unit_attack} ability to place a Corrosion Token on a unit attacked by them.\n"
-"    It reduces the enemy's unit \\svg{defense} by 1 to a minimum of 0.\n"
+"    The Corrosion Token reduces the unit's \\svg{defense} by 1 to a minimum of 0.\n"
 "    A unit can have only one Corrosion Token at a time.\n"
-"    If a unit would gain a second Token, discard one of them.\n"
+"    If a unit would gain a second Corrosion Token, discard one of them.\n"
 "    Unless removed by Spells or other effects, a Corrosion Token remains on the unit until the end of Combat.\n"
+"    \\textit{For example, this Token is given to enemy units by the \\wikilink{units/behemoths}{Behemoths} unit's ability.}\n"
 "  \\end{expansion}"
 msgstr ""
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:307
+#: sections/card_effect_keywords.tex:308
 #, fuzzy
 #| msgid ""
 #| "{2}\n"
@@ -631,12 +632,12 @@ msgstr ""
 "\n"
 
 #. type: wrapfigure
-#: sections/card_effect_keywords.tex:307
+#: sections/card_effect_keywords.tex:308
 msgid "{r}{0.2\\textwidth}"
 msgstr ""
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:310
+#: sections/card_effect_keywords.tex:311
 msgid ""
 "Many cards in \\textbf{Heroes of Might and Magic 3: The Board Game} have "
 "ambiguous or misleading wording.  Fortunately, the developers have clarified "
@@ -644,7 +645,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:314
+#: sections/card_effect_keywords.tex:315
 msgid ""
 "The Community maintains a \\textbf{Fan-Made Wiki}: a collection of nearly "
 "all game components with extensive notes to clarify specific rules.  If you "

--- a/translations/card_effect_keywords.tex/fr.po
+++ b/translations/card_effect_keywords.tex/fr.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-03-30 23:32+0100\n"
+"POT-Creation-Date: 2026-04-09 19:11+0100\n"
 "PO-Revision-Date: 2025-11-29 16:03+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -542,7 +542,7 @@ msgstr ""
 #: sections/card_effect_keywords.tex:236
 #, fuzzy
 #| msgid "\\pagetarget{Other Fields}{\\subheader{Other Fields}}"
-msgid "\\pagetarget{unit keywords}{\\subheader{Unit Ability keywords}}"
+msgid "\\pagetarget{unit keywords}{\\subheader{Tokens on Units}}"
 msgstr "\\pagetarget{Other Fields}{\\subheader{Autres Sites}}"
 
 #. type: Plain text
@@ -568,11 +568,11 @@ msgid ""
 "      \\imagecaption{Weakness Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    \\textbf{\\wikilink{units/sorceresses/\\#few}{``Few'' Sorceresses}} unit from the Cove Faction can use their \\svg{unit_alternative} ability to place a Weakness Token on any unit.  % enemy unit?\n"
-"    A~\\wikilink{units/sorceresses/\\#pack}{\\textbf{``Pack'' of Sorceresses}} places this Token automatically on a unit attacked by them due to their \\svg{unit_attack} ability.\n"
+"    When an effect places a Weakness Token on a unit, it specifies which side to use: $-1$ or $-2$.\n"
 "    A unit with this Token suffers $-1$~\\svg{attack} or $-2$~\\svg{attack}, as indicated by the Token's side.\n"
 "    Each unit can have only one Weakness Token at a time.\n"
 "    If a unit would gain a second one, the player controlling it chooses which one to keep.\n"
+"    \\textit{For example, this Token can be given to units by the \\wikilink{units/sorceresses}{Sorceresses} unit's ability.}\n"
 "    \\begin{center}\n"
 "      \\vspace*{2.5em}\n"
 "      {\\transparent{0.2}\\includegraphics[width=0.9\\linewidth]{\\art/weakness.png}}\n"
@@ -584,7 +584,7 @@ msgid ""
 msgstr ""
 
 #. type: multicols
-#: sections/card_effect_keywords.tex:280
+#: sections/card_effect_keywords.tex:281
 #, no-wrap
 msgid ""
 "  \\begin{expansion}{stronghold,stretchgoals2}\n"
@@ -598,16 +598,17 @@ msgid ""
 "      \\imagecaption{Attack Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    The \\textbf{\\wikilink{units/ogres}{Ogres}} unit from the Stronghold Faction can use their \\svg{unit_alternative} ability to place Attack Tokens on other allied unit cards.\n"
+"    When an effect places an Attack Token on a unit, it specifies which side to use: $1$ or $2$.\n"
 "    Units with such a Token gain an additional 1~\\svg{attack} or 2~\\svg{attack}, as indicated by the Token's side.\n"
 "    Each unit can have only one Attack Token at a time.\n"
 "    If a unit would gain a second one, the player controlling it chooses which one to keep.\n"
+"    \\textit{For example, this Token can be given to units by the \\wikilink{units/ogres}{Ogres} unit's ability.}\n"
 "  \\end{expansion}\n"
 "\n"
 msgstr ""
 
 #. type: multicols
-#: sections/card_effect_keywords.tex:299
+#: sections/card_effect_keywords.tex:300
 #, no-wrap
 msgid ""
 "  \\vspace*{1em}\n"
@@ -622,16 +623,16 @@ msgid ""
 "      \\imagecaption{Corrosion Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    The \\textbf{\\wikilink{units/behemoths}{Behemoths}} unit from the Stronghold Faction can use their \\svg{unit_attack} ability to place a Corrosion Token on a unit attacked by them.\n"
-"    It reduces the enemy's unit \\svg{defense} by 1 to a minimum of 0.\n"
+"    The Corrosion Token reduces the unit's \\svg{defense} by 1 to a minimum of 0.\n"
 "    A unit can have only one Corrosion Token at a time.\n"
-"    If a unit would gain a second Token, discard one of them.\n"
+"    If a unit would gain a second Corrosion Token, discard one of them.\n"
 "    Unless removed by Spells or other effects, a Corrosion Token remains on the unit until the end of Combat.\n"
+"    \\textit{For example, this Token is given to enemy units by the \\wikilink{units/behemoths}{Behemoths} unit's ability.}\n"
 "  \\end{expansion}"
 msgstr ""
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:307
+#: sections/card_effect_keywords.tex:308
 #, fuzzy
 #| msgid ""
 #| "{2}\n"
@@ -644,12 +645,12 @@ msgstr ""
 "\n"
 
 #. type: wrapfigure
-#: sections/card_effect_keywords.tex:307
+#: sections/card_effect_keywords.tex:308
 msgid "{r}{0.2\\textwidth}"
 msgstr ""
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:310
+#: sections/card_effect_keywords.tex:311
 msgid ""
 "Many cards in \\textbf{Heroes of Might and Magic 3: The Board Game} have "
 "ambiguous or misleading wording.  Fortunately, the developers have clarified "
@@ -657,7 +658,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:314
+#: sections/card_effect_keywords.tex:315
 msgid ""
 "The Community maintains a \\textbf{Fan-Made Wiki}: a collection of nearly "
 "all game components with extensive notes to clarify specific rules.  If you "

--- a/translations/card_effect_keywords.tex/he.po
+++ b/translations/card_effect_keywords.tex/he.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-03-30 23:32+0100\n"
+"POT-Creation-Date: 2026-04-09 19:11+0100\n"
 "PO-Revision-Date: 2025-11-29 16:03+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -562,7 +562,7 @@ msgstr ""
 #: sections/card_effect_keywords.tex:236
 #, fuzzy
 #| msgid "\\pagetarget{Other Fields}{Other Fields}"
-msgid "\\pagetarget{unit keywords}{\\subheader{Unit Ability keywords}}"
+msgid "\\pagetarget{unit keywords}{\\subheader{Tokens on Units}}"
 msgstr "\\pagetarget{Other Fields}{שדות אחרים}"
 
 #. type: Plain text
@@ -588,11 +588,11 @@ msgid ""
 "      \\imagecaption{Weakness Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    \\textbf{\\wikilink{units/sorceresses/\\#few}{``Few'' Sorceresses}} unit from the Cove Faction can use their \\svg{unit_alternative} ability to place a Weakness Token on any unit.  % enemy unit?\n"
-"    A~\\wikilink{units/sorceresses/\\#pack}{\\textbf{``Pack'' of Sorceresses}} places this Token automatically on a unit attacked by them due to their \\svg{unit_attack} ability.\n"
+"    When an effect places a Weakness Token on a unit, it specifies which side to use: $-1$ or $-2$.\n"
 "    A unit with this Token suffers $-1$~\\svg{attack} or $-2$~\\svg{attack}, as indicated by the Token's side.\n"
 "    Each unit can have only one Weakness Token at a time.\n"
 "    If a unit would gain a second one, the player controlling it chooses which one to keep.\n"
+"    \\textit{For example, this Token can be given to units by the \\wikilink{units/sorceresses}{Sorceresses} unit's ability.}\n"
 "    \\begin{center}\n"
 "      \\vspace*{2.5em}\n"
 "      {\\transparent{0.2}\\includegraphics[width=0.9\\linewidth]{\\art/weakness.png}}\n"
@@ -604,7 +604,7 @@ msgid ""
 msgstr ""
 
 #. type: multicols
-#: sections/card_effect_keywords.tex:280
+#: sections/card_effect_keywords.tex:281
 #, no-wrap
 msgid ""
 "  \\begin{expansion}{stronghold,stretchgoals2}\n"
@@ -618,16 +618,17 @@ msgid ""
 "      \\imagecaption{Attack Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    The \\textbf{\\wikilink{units/ogres}{Ogres}} unit from the Stronghold Faction can use their \\svg{unit_alternative} ability to place Attack Tokens on other allied unit cards.\n"
+"    When an effect places an Attack Token on a unit, it specifies which side to use: $1$ or $2$.\n"
 "    Units with such a Token gain an additional 1~\\svg{attack} or 2~\\svg{attack}, as indicated by the Token's side.\n"
 "    Each unit can have only one Attack Token at a time.\n"
 "    If a unit would gain a second one, the player controlling it chooses which one to keep.\n"
+"    \\textit{For example, this Token can be given to units by the \\wikilink{units/ogres}{Ogres} unit's ability.}\n"
 "  \\end{expansion}\n"
 "\n"
 msgstr ""
 
 #. type: multicols
-#: sections/card_effect_keywords.tex:299
+#: sections/card_effect_keywords.tex:300
 #, no-wrap
 msgid ""
 "  \\vspace*{1em}\n"
@@ -642,16 +643,16 @@ msgid ""
 "      \\imagecaption{Corrosion Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    The \\textbf{\\wikilink{units/behemoths}{Behemoths}} unit from the Stronghold Faction can use their \\svg{unit_attack} ability to place a Corrosion Token on a unit attacked by them.\n"
-"    It reduces the enemy's unit \\svg{defense} by 1 to a minimum of 0.\n"
+"    The Corrosion Token reduces the unit's \\svg{defense} by 1 to a minimum of 0.\n"
 "    A unit can have only one Corrosion Token at a time.\n"
-"    If a unit would gain a second Token, discard one of them.\n"
+"    If a unit would gain a second Corrosion Token, discard one of them.\n"
 "    Unless removed by Spells or other effects, a Corrosion Token remains on the unit until the end of Combat.\n"
+"    \\textit{For example, this Token is given to enemy units by the \\wikilink{units/behemoths}{Behemoths} unit's ability.}\n"
 "  \\end{expansion}"
 msgstr ""
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:307
+#: sections/card_effect_keywords.tex:308
 #, fuzzy
 #| msgid ""
 #| "{2}\n"
@@ -664,12 +665,12 @@ msgstr ""
 "\n"
 
 #. type: wrapfigure
-#: sections/card_effect_keywords.tex:307
+#: sections/card_effect_keywords.tex:308
 msgid "{r}{0.2\\textwidth}"
 msgstr ""
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:310
+#: sections/card_effect_keywords.tex:311
 msgid ""
 "Many cards in \\textbf{Heroes of Might and Magic 3: The Board Game} have "
 "ambiguous or misleading wording.  Fortunately, the developers have clarified "
@@ -677,7 +678,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:314
+#: sections/card_effect_keywords.tex:315
 msgid ""
 "The Community maintains a \\textbf{Fan-Made Wiki}: a collection of nearly "
 "all game components with extensive notes to clarify specific rules.  If you "

--- a/translations/card_effect_keywords.tex/pl.po
+++ b/translations/card_effect_keywords.tex/pl.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-03-30 23:32+0100\n"
+"POT-Creation-Date: 2026-04-09 19:11+0100\n"
 "PO-Revision-Date: 2025-11-29 16:03+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -635,7 +635,9 @@ msgstr ""
 
 #. type: Plain text
 #: sections/card_effect_keywords.tex:236
-msgid "\\pagetarget{unit keywords}{\\subheader{Unit Ability keywords}}"
+#, fuzzy
+#| msgid "\\pagetarget{unit keywords}{\\subheader{Unit Ability keywords}}"
+msgid "\\pagetarget{unit keywords}{\\subheader{Tokens on Units}}"
 msgstr ""
 "\\pagetarget{unit keywords}{\\subheader{Słowa Kluczowe Zdolności Jednostek}}"
 
@@ -651,7 +653,33 @@ msgstr ""
 
 #. type: multicols
 #: sections/card_effect_keywords.tex:263
-#, no-wrap
+#, fuzzy, no-wrap
+#| msgid ""
+#| "{2}\n"
+#| "  \\begin{expansion}{cove,stretchgoals2}\n"
+#| "    \\pagetarget{Weakness Token}{\\subsection*{Weakness Token}}\n"
+#| "    \\index{Weakness Token}\n"
+#| "    \\setlength\\intextsep{0pt}\n"
+#| "    \\setlength\\columnsep{1em}\n"
+#| "    \\begin{wrapfigure}{r}{0.25\\linewidth}\n"
+#| "      \\centering\n"
+#| "      \\includegraphics[width=0.8\\linewidth]{\\images/weakness-token.png}\\\\\n"
+#| "      \\imagecaption{Weakness Token}\\\\\n"
+#| "      \\vspace{1em}\n"
+#| "    \\end{wrapfigure}\n"
+#| "    \\textbf{\\wikilink{units/sorceresses/\\#few}{``Few'' Sorceresses}} unit from the Cove Faction can use their \\svg{unit_alternative} ability to place a Weakness Token on any unit.  % enemy unit?\n"
+#| "    A~\\wikilink{units/sorceresses/\\#pack}{\\textbf{``Pack'' of Sorceresses}} places this Token automatically on a unit attacked by them due to their \\svg{unit_attack} ability.\n"
+#| "    A unit with this Token suffers $-1$~\\svg{attack} or $-2$~\\svg{attack}, as indicated by the Token's side.\n"
+#| "    Each unit can have only one Weakness Token at a time.\n"
+#| "    If a unit would gain a second one, the player controlling it chooses which one to keep.\n"
+#| "    \\begin{center}\n"
+#| "      \\vspace*{2.5em}\n"
+#| "      {\\transparent{0.2}\\includegraphics[width=0.9\\linewidth]{\\art/weakness.png}}\n"
+#| "      \\vspace*{2em}\n"
+#| "    \\end{center}\n"
+#| "  \\end{expansion}\n"
+#| "  \\columnbreak\n"
+#| "\n"
 msgid ""
 "{2}\n"
 "  \\begin{expansion}{cove,stretchgoals2}\n"
@@ -665,11 +693,11 @@ msgid ""
 "      \\imagecaption{Weakness Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    \\textbf{\\wikilink{units/sorceresses/\\#few}{``Few'' Sorceresses}} unit from the Cove Faction can use their \\svg{unit_alternative} ability to place a Weakness Token on any unit.  % enemy unit?\n"
-"    A~\\wikilink{units/sorceresses/\\#pack}{\\textbf{``Pack'' of Sorceresses}} places this Token automatically on a unit attacked by them due to their \\svg{unit_attack} ability.\n"
+"    When an effect places a Weakness Token on a unit, it specifies which side to use: $-1$ or $-2$.\n"
 "    A unit with this Token suffers $-1$~\\svg{attack} or $-2$~\\svg{attack}, as indicated by the Token's side.\n"
 "    Each unit can have only one Weakness Token at a time.\n"
 "    If a unit would gain a second one, the player controlling it chooses which one to keep.\n"
+"    \\textit{For example, this Token can be given to units by the \\wikilink{units/sorceresses}{Sorceresses} unit's ability.}\n"
 "    \\begin{center}\n"
 "      \\vspace*{2.5em}\n"
 "      {\\transparent{0.2}\\includegraphics[width=0.9\\linewidth]{\\art/weakness.png}}\n"
@@ -706,8 +734,26 @@ msgstr ""
 "\n"
 
 #. type: multicols
-#: sections/card_effect_keywords.tex:280
-#, no-wrap
+#: sections/card_effect_keywords.tex:281
+#, fuzzy, no-wrap
+#| msgid ""
+#| "  \\begin{expansion}{stronghold,stretchgoals2}\n"
+#| "    \\pagetarget{Attack Token}{\\subsection*{Attack Token}}\n"
+#| "    \\index{Attack Token}\n"
+#| "    \\setlength\\intextsep{0pt}\n"
+#| "    \\setlength\\columnsep{1em}\n"
+#| "    \\begin{wrapfigure}{r}{0.2\\linewidth}\n"
+#| "      \\centering\n"
+#| "      \\includegraphics[width=\\linewidth]{\\images/attack-token.png}\\\\\n"
+#| "      \\imagecaption{Attack Token}\\\\\n"
+#| "      \\vspace{1em}\n"
+#| "    \\end{wrapfigure}\n"
+#| "    The \\textbf{\\wikilink{units/ogres}{Ogres}} unit from the Stronghold Faction can use their \\svg{unit_alternative} ability to place Attack Tokens on other allied unit cards.\n"
+#| "    Units with such a Token gain an additional 1~\\svg{attack} or 2~\\svg{attack}, as indicated by the Token's side.\n"
+#| "    Each unit can have only one Attack Token at a time.\n"
+#| "    If a unit would gain a second one, the player controlling it chooses which one to keep.\n"
+#| "  \\end{expansion}\n"
+#| "\n"
 msgid ""
 "  \\begin{expansion}{stronghold,stretchgoals2}\n"
 "    \\pagetarget{Attack Token}{\\subsection*{Attack Token}}\n"
@@ -720,10 +766,11 @@ msgid ""
 "      \\imagecaption{Attack Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    The \\textbf{\\wikilink{units/ogres}{Ogres}} unit from the Stronghold Faction can use their \\svg{unit_alternative} ability to place Attack Tokens on other allied unit cards.\n"
+"    When an effect places an Attack Token on a unit, it specifies which side to use: $1$ or $2$.\n"
 "    Units with such a Token gain an additional 1~\\svg{attack} or 2~\\svg{attack}, as indicated by the Token's side.\n"
 "    Each unit can have only one Attack Token at a time.\n"
 "    If a unit would gain a second one, the player controlling it chooses which one to keep.\n"
+"    \\textit{For example, this Token can be given to units by the \\wikilink{units/ogres}{Ogres} unit's ability.}\n"
 "  \\end{expansion}\n"
 "\n"
 msgstr ""
@@ -746,8 +793,27 @@ msgstr ""
 "\n"
 
 #. type: multicols
-#: sections/card_effect_keywords.tex:299
-#, no-wrap
+#: sections/card_effect_keywords.tex:300
+#, fuzzy, no-wrap
+#| msgid ""
+#| "  \\vspace*{1em}\n"
+#| "  \\begin{expansion}{stronghold}\n"
+#| "    \\pagetarget{Corrosion Token}{\\subsection*{Corrosion Token}}\n"
+#| "    \\index{Corrosion Token}\n"
+#| "    \\setlength\\intextsep{0pt}\n"
+#| "    \\setlength\\columnsep{1em}\n"
+#| "    \\begin{wrapfigure}{r}{0.25\\linewidth}\n"
+#| "      \\centering\n"
+#| "      \\includegraphics[width=0.8\\linewidth]{\\images/corrosion-token.png}\\\\\n"
+#| "      \\imagecaption{Corrosion Token}\\\\\n"
+#| "      \\vspace{1em}\n"
+#| "    \\end{wrapfigure}\n"
+#| "    The \\textbf{\\wikilink{units/behemoths}{Behemoths}} unit from the Stronghold Faction can use their \\svg{unit_attack} ability to place a Corrosion Token on a unit attacked by them.\n"
+#| "    It reduces the enemy's unit \\svg{defense} by 1 to a minimum of 0.\n"
+#| "    A unit can have only one Corrosion Token at a time.\n"
+#| "    If a unit would gain a second Token, discard one of them.\n"
+#| "    Unless removed by Spells or other effects, a Corrosion Token remains on the unit until the end of Combat.\n"
+#| "  \\end{expansion}"
 msgid ""
 "  \\vspace*{1em}\n"
 "  \\begin{expansion}{stronghold}\n"
@@ -761,11 +827,11 @@ msgid ""
 "      \\imagecaption{Corrosion Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    The \\textbf{\\wikilink{units/behemoths}{Behemoths}} unit from the Stronghold Faction can use their \\svg{unit_attack} ability to place a Corrosion Token on a unit attacked by them.\n"
-"    It reduces the enemy's unit \\svg{defense} by 1 to a minimum of 0.\n"
+"    The Corrosion Token reduces the unit's \\svg{defense} by 1 to a minimum of 0.\n"
 "    A unit can have only one Corrosion Token at a time.\n"
-"    If a unit would gain a second Token, discard one of them.\n"
+"    If a unit would gain a second Corrosion Token, discard one of them.\n"
 "    Unless removed by Spells or other effects, a Corrosion Token remains on the unit until the end of Combat.\n"
+"    \\textit{For example, this Token is given to enemy units by the \\wikilink{units/behemoths}{Behemoths} unit's ability.}\n"
 "  \\end{expansion}"
 msgstr ""
 "  \\vspace*{1em}\n"
@@ -788,17 +854,17 @@ msgstr ""
 "  \\end{expansion}"
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:307
+#: sections/card_effect_keywords.tex:308
 msgid "\\pagetarget{wiki}{\\subheader{Fan-Made Wiki}}"
 msgstr "\\pagetarget{wiki}{\\subheader{Fanowska Wiki}}"
 
 #. type: wrapfigure
-#: sections/card_effect_keywords.tex:307
+#: sections/card_effect_keywords.tex:308
 msgid "{r}{0.2\\textwidth}"
 msgstr "{r}{0.2\\textwidth}"
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:310
+#: sections/card_effect_keywords.tex:311
 msgid ""
 "Many cards in \\textbf{Heroes of Might and Magic 3: The Board Game} have "
 "ambiguous or misleading wording.  Fortunately, the developers have clarified "
@@ -809,7 +875,7 @@ msgstr ""
 "wiele z nich."
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:314
+#: sections/card_effect_keywords.tex:315
 msgid ""
 "The Community maintains a \\textbf{Fan-Made Wiki}: a collection of nearly "
 "all game components with extensive notes to clarify specific rules.  If you "

--- a/translations/card_effect_keywords.tex/ru.po
+++ b/translations/card_effect_keywords.tex/ru.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-03-30 23:32+0100\n"
+"POT-Creation-Date: 2026-04-09 19:11+0100\n"
 "PO-Revision-Date: 2025-11-29 16:03+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -500,7 +500,7 @@ msgstr ""
 #: sections/card_effect_keywords.tex:236
 #, fuzzy
 #| msgid "\\pagetarget{Other Fields}{Other Fields}"
-msgid "\\pagetarget{unit keywords}{\\subheader{Unit Ability keywords}}"
+msgid "\\pagetarget{unit keywords}{\\subheader{Tokens on Units}}"
 msgstr "\\pagetarget{Other Fields}{Другие поля}"
 
 #. type: Plain text
@@ -526,11 +526,11 @@ msgid ""
 "      \\imagecaption{Weakness Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    \\textbf{\\wikilink{units/sorceresses/\\#few}{``Few'' Sorceresses}} unit from the Cove Faction can use their \\svg{unit_alternative} ability to place a Weakness Token on any unit.  % enemy unit?\n"
-"    A~\\wikilink{units/sorceresses/\\#pack}{\\textbf{``Pack'' of Sorceresses}} places this Token automatically on a unit attacked by them due to their \\svg{unit_attack} ability.\n"
+"    When an effect places a Weakness Token on a unit, it specifies which side to use: $-1$ or $-2$.\n"
 "    A unit with this Token suffers $-1$~\\svg{attack} or $-2$~\\svg{attack}, as indicated by the Token's side.\n"
 "    Each unit can have only one Weakness Token at a time.\n"
 "    If a unit would gain a second one, the player controlling it chooses which one to keep.\n"
+"    \\textit{For example, this Token can be given to units by the \\wikilink{units/sorceresses}{Sorceresses} unit's ability.}\n"
 "    \\begin{center}\n"
 "      \\vspace*{2.5em}\n"
 "      {\\transparent{0.2}\\includegraphics[width=0.9\\linewidth]{\\art/weakness.png}}\n"
@@ -542,7 +542,7 @@ msgid ""
 msgstr ""
 
 #. type: multicols
-#: sections/card_effect_keywords.tex:280
+#: sections/card_effect_keywords.tex:281
 #, no-wrap
 msgid ""
 "  \\begin{expansion}{stronghold,stretchgoals2}\n"
@@ -556,16 +556,17 @@ msgid ""
 "      \\imagecaption{Attack Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    The \\textbf{\\wikilink{units/ogres}{Ogres}} unit from the Stronghold Faction can use their \\svg{unit_alternative} ability to place Attack Tokens on other allied unit cards.\n"
+"    When an effect places an Attack Token on a unit, it specifies which side to use: $1$ or $2$.\n"
 "    Units with such a Token gain an additional 1~\\svg{attack} or 2~\\svg{attack}, as indicated by the Token's side.\n"
 "    Each unit can have only one Attack Token at a time.\n"
 "    If a unit would gain a second one, the player controlling it chooses which one to keep.\n"
+"    \\textit{For example, this Token can be given to units by the \\wikilink{units/ogres}{Ogres} unit's ability.}\n"
 "  \\end{expansion}\n"
 "\n"
 msgstr ""
 
 #. type: multicols
-#: sections/card_effect_keywords.tex:299
+#: sections/card_effect_keywords.tex:300
 #, no-wrap
 msgid ""
 "  \\vspace*{1em}\n"
@@ -580,16 +581,16 @@ msgid ""
 "      \\imagecaption{Corrosion Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    The \\textbf{\\wikilink{units/behemoths}{Behemoths}} unit from the Stronghold Faction can use their \\svg{unit_attack} ability to place a Corrosion Token on a unit attacked by them.\n"
-"    It reduces the enemy's unit \\svg{defense} by 1 to a minimum of 0.\n"
+"    The Corrosion Token reduces the unit's \\svg{defense} by 1 to a minimum of 0.\n"
 "    A unit can have only one Corrosion Token at a time.\n"
-"    If a unit would gain a second Token, discard one of them.\n"
+"    If a unit would gain a second Corrosion Token, discard one of them.\n"
 "    Unless removed by Spells or other effects, a Corrosion Token remains on the unit until the end of Combat.\n"
+"    \\textit{For example, this Token is given to enemy units by the \\wikilink{units/behemoths}{Behemoths} unit's ability.}\n"
 "  \\end{expansion}"
 msgstr ""
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:307
+#: sections/card_effect_keywords.tex:308
 #, fuzzy
 #| msgid ""
 #| "{2}\n"
@@ -602,12 +603,12 @@ msgstr ""
 "\n"
 
 #. type: wrapfigure
-#: sections/card_effect_keywords.tex:307
+#: sections/card_effect_keywords.tex:308
 msgid "{r}{0.2\\textwidth}"
 msgstr ""
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:310
+#: sections/card_effect_keywords.tex:311
 msgid ""
 "Many cards in \\textbf{Heroes of Might and Magic 3: The Board Game} have "
 "ambiguous or misleading wording.  Fortunately, the developers have clarified "
@@ -615,7 +616,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:314
+#: sections/card_effect_keywords.tex:315
 msgid ""
 "The Community maintains a \\textbf{Fan-Made Wiki}: a collection of nearly "
 "all game components with extensive notes to clarify specific rules.  If you "

--- a/translations/card_effect_keywords.tex/ua.po
+++ b/translations/card_effect_keywords.tex/ua.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-03-30 23:32+0100\n"
+"POT-Creation-Date: 2026-04-09 19:11+0100\n"
 "PO-Revision-Date: 2025-11-29 16:03+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -561,7 +561,7 @@ msgstr ""
 #: sections/card_effect_keywords.tex:236
 #, fuzzy
 #| msgid "\\pagetarget{Other Fields}{Other Fields}"
-msgid "\\pagetarget{unit keywords}{\\subheader{Unit Ability keywords}}"
+msgid "\\pagetarget{unit keywords}{\\subheader{Tokens on Units}}"
 msgstr "\\pagetarget{Other Fields}{Інші Поля}"
 
 #. type: Plain text
@@ -587,11 +587,11 @@ msgid ""
 "      \\imagecaption{Weakness Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    \\textbf{\\wikilink{units/sorceresses/\\#few}{``Few'' Sorceresses}} unit from the Cove Faction can use their \\svg{unit_alternative} ability to place a Weakness Token on any unit.  % enemy unit?\n"
-"    A~\\wikilink{units/sorceresses/\\#pack}{\\textbf{``Pack'' of Sorceresses}} places this Token automatically on a unit attacked by them due to their \\svg{unit_attack} ability.\n"
+"    When an effect places a Weakness Token on a unit, it specifies which side to use: $-1$ or $-2$.\n"
 "    A unit with this Token suffers $-1$~\\svg{attack} or $-2$~\\svg{attack}, as indicated by the Token's side.\n"
 "    Each unit can have only one Weakness Token at a time.\n"
 "    If a unit would gain a second one, the player controlling it chooses which one to keep.\n"
+"    \\textit{For example, this Token can be given to units by the \\wikilink{units/sorceresses}{Sorceresses} unit's ability.}\n"
 "    \\begin{center}\n"
 "      \\vspace*{2.5em}\n"
 "      {\\transparent{0.2}\\includegraphics[width=0.9\\linewidth]{\\art/weakness.png}}\n"
@@ -603,7 +603,7 @@ msgid ""
 msgstr ""
 
 #. type: multicols
-#: sections/card_effect_keywords.tex:280
+#: sections/card_effect_keywords.tex:281
 #, no-wrap
 msgid ""
 "  \\begin{expansion}{stronghold,stretchgoals2}\n"
@@ -617,16 +617,17 @@ msgid ""
 "      \\imagecaption{Attack Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    The \\textbf{\\wikilink{units/ogres}{Ogres}} unit from the Stronghold Faction can use their \\svg{unit_alternative} ability to place Attack Tokens on other allied unit cards.\n"
+"    When an effect places an Attack Token on a unit, it specifies which side to use: $1$ or $2$.\n"
 "    Units with such a Token gain an additional 1~\\svg{attack} or 2~\\svg{attack}, as indicated by the Token's side.\n"
 "    Each unit can have only one Attack Token at a time.\n"
 "    If a unit would gain a second one, the player controlling it chooses which one to keep.\n"
+"    \\textit{For example, this Token can be given to units by the \\wikilink{units/ogres}{Ogres} unit's ability.}\n"
 "  \\end{expansion}\n"
 "\n"
 msgstr ""
 
 #. type: multicols
-#: sections/card_effect_keywords.tex:299
+#: sections/card_effect_keywords.tex:300
 #, no-wrap
 msgid ""
 "  \\vspace*{1em}\n"
@@ -641,16 +642,16 @@ msgid ""
 "      \\imagecaption{Corrosion Token}\\\\\n"
 "      \\vspace{1em}\n"
 "    \\end{wrapfigure}\n"
-"    The \\textbf{\\wikilink{units/behemoths}{Behemoths}} unit from the Stronghold Faction can use their \\svg{unit_attack} ability to place a Corrosion Token on a unit attacked by them.\n"
-"    It reduces the enemy's unit \\svg{defense} by 1 to a minimum of 0.\n"
+"    The Corrosion Token reduces the unit's \\svg{defense} by 1 to a minimum of 0.\n"
 "    A unit can have only one Corrosion Token at a time.\n"
-"    If a unit would gain a second Token, discard one of them.\n"
+"    If a unit would gain a second Corrosion Token, discard one of them.\n"
 "    Unless removed by Spells or other effects, a Corrosion Token remains on the unit until the end of Combat.\n"
+"    \\textit{For example, this Token is given to enemy units by the \\wikilink{units/behemoths}{Behemoths} unit's ability.}\n"
 "  \\end{expansion}"
 msgstr ""
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:307
+#: sections/card_effect_keywords.tex:308
 #, fuzzy
 #| msgid ""
 #| "{2}\n"
@@ -663,12 +664,12 @@ msgstr ""
 "\n"
 
 #. type: wrapfigure
-#: sections/card_effect_keywords.tex:307
+#: sections/card_effect_keywords.tex:308
 msgid "{r}{0.2\\textwidth}"
 msgstr ""
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:310
+#: sections/card_effect_keywords.tex:311
 msgid ""
 "Many cards in \\textbf{Heroes of Might and Magic 3: The Board Game} have "
 "ambiguous or misleading wording.  Fortunately, the developers have clarified "
@@ -676,7 +677,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: sections/card_effect_keywords.tex:314
+#: sections/card_effect_keywords.tex:315
 msgid ""
 "The Community maintains a \\textbf{Fan-Made Wiki}: a collection of nearly "
 "all game components with extensive notes to clarify specific rules.  If you "


### PR DESCRIPTION
fix #1050
<img width="2482" height="1754" alt="en-89" src="https://github.com/user-attachments/assets/544871b6-d594-4071-a27f-f64a9dfabf3d" />

I'm not sure about the example sentence, probably should just be dropped