### PR TITLE
Use English name for languages instead of transliterations

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -18,14 +18,14 @@ jobs:
           {
             "include": [
               { "language_name": "English", "language": "en", "display": "🇺🇸 English"},
-              { "language_name": "Polski", "language": "pl", "display": "🇵🇱 Polski"},
-              { "language_name": "Espanol", "language": "es", "display": "🇪🇸 Español"},
-              { "language_name": "Francais", "language": "fr", "display": "🇫🇷 Français"},
-              { "language_name": "Russkiy", "language": "ru", "display": "🇷🇺 Русский"},
-              { "language_name": "Ukrainska", "language": "ua", "display": "🇺🇦 Українська"},
-              { "language_name": "Deutsch", "language": "de", "display": "🇩🇪 Deutsch"},
-              { "language_name": "Cestina", "language": "cs", "display": "🇨🇿 Čeština"},
-              { "language_name": "Ivrit", "language": "he", "display": "🇮🇱 עברית"}
+              { "language_name": "Polish", "language": "pl", "display": "🇵🇱 Polski"},
+              { "language_name": "Spanish", "language": "es", "display": "🇪🇸 Español"},
+              { "language_name": "French", "language": "fr", "display": "🇫🇷 Français"},
+              { "language_name": "Russian", "language": "ru", "display": "🇷🇺 Русский"},
+              { "language_name": "Ukrainian", "language": "ua", "display": "🇺🇦 Українська"},
+              { "language_name": "German", "language": "de", "display": "🇩🇪 Deutsch"},
+              { "language_name": "Czech", "language": "cs", "display": "🇨🇿 Čeština"},
+              { "language_name": "Hebrew", "language": "he", "display": "🇮🇱 עברית"}
             ]
           }
           EOF

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -9,14 +9,14 @@ FILE_VERSION=$(echo "${VERSION}" | tr . _)
 
 declare -A languages=(
   ["en"]="English"
-  ["pl"]="Polski"
-  ["es"]="Espanol"
-  ["fr"]="Francais"
-  ["ua"]="Ukrainska"
-  ["cs"]="Cestina"
-  ["ru"]="Russkiy"
-  ["he"]="Ivrit"
-  ["de"]="Deutsch"
+  ["pl"]="Polish"
+  ["es"]="Spanish"
+  ["fr"]="French"
+  ["ua"]="Ukrainian"
+  ["cs"]="Czech"
+  ["ru"]="Russian"
+  ["he"]="Hebrew"
+  ["de"]="German"
 )
 
 echo "Building release ${VERSION} for ${languages[$LANGUAGE]}..."


### PR DESCRIPTION
From this list it becomes hard to find the correct name especially when such transliteration is not commonly used. And it becomes hard to understand what is what here