### PR TITLE
Update GH actions

### DIFF
--- a/.github/workflows/build-and-publish-rule-book.yaml
+++ b/.github/workflows/build-and-publish-rule-book.yaml
@@ -130,7 +130,7 @@ jobs:
           merge-multiple: true
 
       - name: Publish ${{ matrix.language }} in artifacts repository
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@v4.1
         with:
           deploy_key: ${{ secrets.SSH_DEPLOY_KEY_BUILD_ARTIFACTS }}
           external_repository: qwrtln/Homm3BG-build-artifacts

--- a/.github/workflows/build-and-publish-rule-book.yaml
+++ b/.github/workflows/build-and-publish-rule-book.yaml
@@ -130,7 +130,7 @@ jobs:
           merge-multiple: true
 
       - name: Publish ${{ matrix.language }} in artifacts repository
-        uses: peaceiris/actions-gh-pages@v4.1
+        uses: peaceiris/actions-gh-pages@v4.1.0
         with:
           deploy_key: ${{ secrets.SSH_DEPLOY_KEY_BUILD_ARTIFACTS }}
           external_repository: qwrtln/Homm3BG-build-artifacts

--- a/.github/workflows/pdf-build.yaml
+++ b/.github/workflows/pdf-build.yaml
@@ -168,7 +168,7 @@ jobs:
 
       - name: Optimize PDF
         id: optimize
-        uses: qwrtln/optimize-pdf@v1
+        uses: qwrtln/optimize-pdf@v10.07
         if: steps.cache-pdf.outputs.cache-hit != 'true'
         with:
           file-name: main_${{ inputs.language }}.pdf


### PR DESCRIPTION
1. Ghostscript bump 10.05 -> 10.07
2. [Pages action bump](https://github.com/peaceiris/actions-gh-pages/releases/tag/v4.1.0) to get rid of Node 20 deprecation warning